### PR TITLE
Add snapshot of lenovorgestrel only

### DIFF
--- a/tests/testthat/data/Levonorgestrel.json
+++ b/tests/testthat/data/Levonorgestrel.json
@@ -1,0 +1,25504 @@
+{
+  "Version": 79,
+  "ExpressionProfiles": [
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Woman",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.0761,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Woman",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2220.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Woman",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Woman",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Woman SHBG 40% less",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.04566,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Woman SHBG 40% less",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2220.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Woman SHBG 40% less",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Woman SHBG 40% less",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Women",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2220.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Women",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Women",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Women",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ALB|Relative expression",
+          "Value": 0.0795482826
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ALB|Relative expression",
+          "Value": 0.0052493348436
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ALB|Relative expression",
+          "Value": 0.9157441694
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ALB|Relative expression",
+          "Value": 0.065872515
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|Caecum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|Rectum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ALB|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ALB|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ALB|Relative expression",
+          "Value": 0.0152761909
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ALB|Relative expression",
+          "Value": 0.0250122822
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ALB|Relative expression",
+          "Value": 0.0033171875829
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ALB|Relative expression",
+          "Value": 0.2295954406
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ALB|Relative expression",
+          "Value": 0.0021486288218
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Natavio et al 2019 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2220.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Natavio et al 2019 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Natavio et al 2019 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.0276,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Natavio et al 2019 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ALB|Relative expression",
+          "Value": 0.0795482826
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ALB|Relative expression",
+          "Value": 0.0052493348436
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ALB|Relative expression",
+          "Value": 0.9157441694
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ALB|Relative expression",
+          "Value": 0.065872515
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|Caecum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|Rectum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ALB|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ALB|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ALB|Relative expression",
+          "Value": 0.0152761909
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ALB|Relative expression",
+          "Value": 0.0250122822
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ALB|Relative expression",
+          "Value": 0.0033171875829
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ALB|Relative expression",
+          "Value": 0.2295954406
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ALB|Relative expression",
+          "Value": 0.0021486288218
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Transporter",
+      "Species": "Human",
+      "Molecule": "ABCB1",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "ABCB1|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ABCB1|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ABCB1|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0242518189
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ABCB1|Relative expression",
+          "Value": 0.07608904
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ABCB1|Relative expression",
+          "Value": 0.017417973
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0419198107
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ABCB1|Relative expression",
+          "Value": 0.7092198582
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1108416465
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1916810427
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1916810427
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0657549316
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0128342959
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0142510688
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ABCB1|Relative expression",
+          "Value": 0.2808543974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0742555692
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0260852897
+        }
+      ],
+      "TransportType": "Efflux",
+      "Expression": [
+        {
+          "Name": "Bone",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "EffluxBrainInterstitialToPlasma",
+          "CompartmentName": "Plasma"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "EffluxBrainTissueToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Fat",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Gonads",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Heart",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "ExcretionKidney",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Stomach",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "SmallIntestine",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LargeIntestine",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Lung",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Muscle",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pancreas",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Skin",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Spleen",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "BloodCells",
+          "TransportDirection": "EffluxBloodCellsToPlasma"
+        },
+        {
+          "Name": "VascularEndothelium",
+          "TransportDirection": "EffluxInterstitialToPlasma"
+        }
+      ]
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "AADAC",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|Relative expression in blood cells",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|Relative expression in plasma",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|AADAC|Relative expression",
+          "Value": 4.8717948718E-05
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|AADAC|Relative expression",
+          "Value": 3.9743589744E-05
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|AADAC|Relative expression",
+          "Value": 0.0011923076923
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|AADAC|Relative expression",
+          "Value": 0.0026602564103
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|AADAC|Relative expression",
+          "Value": 5.7051282051E-05
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|AADAC|Relative expression",
+          "Value": 0.0269230769
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|AADAC|Relative expression",
+          "Value": 0.00020833333333
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|AADAC|Relative expression",
+          "Value": 0.1474358974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|AADAC|Relative expression",
+          "Value": 0.00037115384615
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|AADAC|Relative expression",
+          "Value": 0.0775641026
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Transporter",
+      "Species": "Human",
+      "Molecule": "OATP1B1",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00014166666667
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0141666667
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0008253968254
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|OATP1B1|Relative expression",
+          "Value": 4.0079365079E-05
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00064682539683
+        }
+      ],
+      "TransportType": "Influx",
+      "Expression": [
+        {
+          "Name": "Bone",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "InfluxBrainPlasmaToInterstitial",
+          "CompartmentName": "Plasma"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "InfluxBrainInterstitialToTissue",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Fat",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Gonads",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Heart",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "ExcretionKidney",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Stomach",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "SmallIntestine",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LargeIntestine",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Lung",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Muscle",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pancreas",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Skin",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Spleen",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "BloodCells",
+          "TransportDirection": "InfluxPlasmaToBloodCells"
+        },
+        {
+          "Name": "VascularEndothelium",
+          "TransportDirection": "InfluxPlasmaToInterstitial"
+        }
+      ]
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ATP1A2",
+      "Category": "Bayer Study 19604 - DDI Rifampicin",
+      "Parameters": [
+        {
+          "Path": "ATP1A2|Fraction expressed on plasma-side membrane of vascular endothelium",
+          "Value": 1.0
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0062154033171
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ATP1A2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0508741242
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.3179118843
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0158938619
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0272345453
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.7034193524
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0073903254795
+        },
+        {
+          "Path": "Organism|Skin|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0389467988
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0103243118
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0309435884
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.0761,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Bayer Study 19604",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Praditpan et al 2017 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2220.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Praditpan et al 2017 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Praditpan et al 2017 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.0276,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Praditpan et al 2017 - Class I and II BMI",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ALB|Relative expression",
+          "Value": 0.0795482826
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ALB|Relative expression",
+          "Value": 0.0052493348436
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ALB|Relative expression",
+          "Value": 0.9157441694
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ALB|Relative expression",
+          "Value": 0.065872515
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|Caecum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|Rectum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ALB|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ALB|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ALB|Relative expression",
+          "Value": 0.0152761909
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ALB|Relative expression",
+          "Value": 0.0250122822
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ALB|Relative expression",
+          "Value": 0.0033171875829
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ALB|Relative expression",
+          "Value": 0.0049490868507
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ALB|Relative expression",
+          "Value": 0.2295954406
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ALB|Relative expression",
+          "Value": 0.0021486288218
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Woman SHBG 40% more",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.10654,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Woman SHBG 40% more",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2220.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Woman SHBG 40% more",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Woman SHBG 40% more",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Transporter",
+      "Species": "Human",
+      "Molecule": "ABCB1",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "ABCB1|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ABCB1|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ABCB1|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0242518189
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ABCB1|Relative expression",
+          "Value": 0.07608904
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ABCB1|Relative expression",
+          "Value": 0.017417973
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0419198107
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ABCB1|Relative expression",
+          "Value": 0.7092198582
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1108416465
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1916810427
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1916810427
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0657549316
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0128342959
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0142510688
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ABCB1|Relative expression",
+          "Value": 0.2808543974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0742555692
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0260852897
+        }
+      ],
+      "TransportType": "Efflux",
+      "Expression": [
+        {
+          "Name": "Bone",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "EffluxBrainInterstitialToPlasma",
+          "CompartmentName": "Plasma"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "EffluxBrainTissueToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Fat",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Gonads",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Heart",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "ExcretionKidney",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Stomach",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "SmallIntestine",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LargeIntestine",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Lung",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Muscle",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pancreas",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Skin",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Spleen",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "BloodCells",
+          "TransportDirection": "EffluxBloodCellsToPlasma"
+        },
+        {
+          "Name": "VascularEndothelium",
+          "TransportDirection": "EffluxInterstitialToPlasma"
+        }
+      ]
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "AADAC",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|Relative expression in blood cells",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|Relative expression in plasma",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|AADAC|Relative expression",
+          "Value": 4.8717948718E-05
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|AADAC|Relative expression",
+          "Value": 3.9743589744E-05
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|AADAC|Relative expression",
+          "Value": 0.0011923076923
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|AADAC|Relative expression",
+          "Value": 0.0026602564103
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|AADAC|Relative expression",
+          "Value": 5.7051282051E-05
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|AADAC|Relative expression",
+          "Value": 0.0269230769
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|AADAC|Relative expression",
+          "Value": 0.00020833333333
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|AADAC|Relative expression",
+          "Value": 0.1474358974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|AADAC|Relative expression",
+          "Value": 0.00037115384615
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|AADAC|Relative expression",
+          "Value": 0.0775641026
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Transporter",
+      "Species": "Human",
+      "Molecule": "OATP1B1",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00014166666667
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0141666667
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0008253968254
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|OATP1B1|Relative expression",
+          "Value": 4.0079365079E-05
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00064682539683
+        }
+      ],
+      "TransportType": "Influx",
+      "Expression": [
+        {
+          "Name": "Bone",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "InfluxBrainPlasmaToInterstitial",
+          "CompartmentName": "Plasma"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "InfluxBrainInterstitialToTissue",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Fat",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Gonads",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Heart",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "ExcretionKidney",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Stomach",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "SmallIntestine",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LargeIntestine",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Lung",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Muscle",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pancreas",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Skin",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Spleen",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "BloodCells",
+          "TransportDirection": "InfluxPlasmaToBloodCells"
+        },
+        {
+          "Name": "VascularEndothelium",
+          "TransportDirection": "InfluxPlasmaToInterstitial"
+        }
+      ]
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ATP1A2",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "ATP1A2|Fraction expressed on plasma-side membrane of vascular endothelium",
+          "Value": 1.0
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0062154033171
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ATP1A2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0508741242
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.3179118843
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0158938619
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0272345453
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.7034193524
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0073903254795
+        },
+        {
+          "Path": "Organism|Skin|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0389467988
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0103243118
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0309435884
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.0761,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Healthy women",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    },
+    {
+      "Type": "Transporter",
+      "Species": "Human",
+      "Molecule": "ABCB1",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "ABCB1|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ABCB1|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ABCB1|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0242518189
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ABCB1|Relative expression",
+          "Value": 0.07608904
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ABCB1|Relative expression",
+          "Value": 0.017417973
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0419198107
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ABCB1|Relative expression",
+          "Value": 0.7092198582
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1108416465
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ABCB1|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1916810427
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ABCB1|Relative expression",
+          "Value": 0.1916810427
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0657549316
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0128342959
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0142510688
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ABCB1|Relative expression",
+          "Value": 0.2808543974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ABCB1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0742555692
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ABCB1|Relative expression",
+          "Value": 0.0260852897
+        }
+      ],
+      "TransportType": "Efflux",
+      "Expression": [
+        {
+          "Name": "Bone",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "EffluxBrainInterstitialToPlasma",
+          "CompartmentName": "Plasma"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "EffluxBrainTissueToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Fat",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Gonads",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Heart",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "ExcretionKidney",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Stomach",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "SmallIntestine",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LargeIntestine",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "EffluxMucosaIntracellularToLumen",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Lung",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Muscle",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pancreas",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Skin",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Spleen",
+          "TransportDirection": "EffluxIntracellularToInterstitial",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "BloodCells",
+          "TransportDirection": "EffluxBloodCellsToPlasma"
+        },
+        {
+          "Name": "VascularEndothelium",
+          "TransportDirection": "EffluxInterstitialToPlasma"
+        }
+      ]
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP3A4",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP3A4"
+      }
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "AADAC",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|Relative expression in blood cells",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|Relative expression in plasma",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|AADAC|Relative expression",
+          "Value": 4.8717948718E-05
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|AADAC|Relative expression",
+          "Value": 3.9743589744E-05
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|AADAC|Relative expression",
+          "Value": 0.0011923076923
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|AADAC|Relative expression",
+          "Value": 0.0026602564103
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|AADAC|Relative expression",
+          "Value": 5.7051282051E-05
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|AADAC|Relative expression",
+          "Value": 0.0269230769
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|AADAC|Relative expression",
+          "Value": 0.00020833333333
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|AADAC|Relative expression",
+          "Value": 0.1474358974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|AADAC|Relative expression",
+          "Value": 0.00037115384615
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|AADAC|Relative expression",
+          "Value": 0.0775641026
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "Transporter",
+      "Species": "Human",
+      "Molecule": "OATP1B1",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00014166666667
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0141666667
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0008253968254
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|OATP1B1|Relative expression",
+          "Value": 4.0079365079E-05
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00064682539683
+        }
+      ],
+      "TransportType": "Influx",
+      "Expression": [
+        {
+          "Name": "Bone",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "InfluxBrainPlasmaToInterstitial",
+          "CompartmentName": "Plasma"
+        },
+        {
+          "Name": "Brain",
+          "TransportDirection": "InfluxBrainInterstitialToTissue",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Fat",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Gonads",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Heart",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Kidney",
+          "TransportDirection": "ExcretionKidney",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Stomach",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "SmallIntestine",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Duodenum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperJejunum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerJejunum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "UpperIleum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "LowerIleum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "LargeIntestine",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Caecum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonAscendens",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonTransversum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonDescendens",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "ColonSigmoid",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Rectum",
+          "TransportDirection": "InfluxLumenToMucosaIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Periportal",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Interstitial"
+        },
+        {
+          "Name": "Pericentral",
+          "TransportDirection": "ExcretionLiver",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Lung",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Muscle",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Pancreas",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Skin",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "Spleen",
+          "TransportDirection": "InfluxInterstitialToIntracellular",
+          "CompartmentName": "Intracellular"
+        },
+        {
+          "Name": "BloodCells",
+          "TransportDirection": "InfluxPlasmaToBloodCells"
+        },
+        {
+          "Name": "VascularEndothelium",
+          "TransportDirection": "InfluxPlasmaToInterstitial"
+        }
+      ]
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ATP1A2",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "ATP1A2|Fraction expressed on plasma-side membrane of vascular endothelium",
+          "Value": 1.0
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 2160.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0062154033171
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ATP1A2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0508741242
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.3179118843
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0158938619
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0272345453
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.7034193524
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0073903254795
+        },
+        {
+          "Path": "Organism|Skin|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0389467988
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0103243118
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0309435884
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
+    },
+    {
+      "Type": "Enzyme",
+      "Species": "Human",
+      "Molecule": "CYP2C9",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 1380.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 6240.0,
+          "Unit": "min"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+      "Ontogeny": {
+        "Name": "CYP2C9"
+      }
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "SHBG",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 0.0761,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 10080.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
+    },
+    {
+      "Type": "OtherProtein",
+      "Species": "Human",
+      "Molecule": "ALB",
+      "Category": "Obese Women",
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 700.0,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 28800.0,
+          "Unit": "min",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ],
+      "Localization": "Interstitial, BloodCellsIntracellular, VascMembraneTissueSide"
+    }
+  ],
+  "Individuals": [
+    {
+      "Name": "Woman",
+      "Seed": 11243912,
+      "OriginData": {
+        "CalculationMethods": [
+          "Body surface area - Mosteller",
+          "SurfaceAreaPlsInt_VAR1"
+        ],
+        "Species": "Human",
+        "Population": "European_ICRP_2002",
+        "Gender": "FEMALE",
+        "Age": {
+          "Value": 30.0,
+          "Unit": "year(s)"
+        }
+      },
+      "ExpressionProfiles": [
+        "SHBG|Human|Woman",
+        "CYP3A4|Human|Woman",
+        "CYP2C9|Human|Woman",
+        "ALB|Human|Woman"
+      ]
+    },
+    {
+      "Name": "Woman SHBG 40% less",
+      "Seed": 11243912,
+      "OriginData": {
+        "CalculationMethods": [
+          "Body surface area - Mosteller",
+          "SurfaceAreaPlsInt_VAR1"
+        ],
+        "Species": "Human",
+        "Population": "European_ICRP_2002",
+        "Gender": "FEMALE",
+        "Age": {
+          "Value": 30.0,
+          "Unit": "year(s)"
+        }
+      },
+      "ExpressionProfiles": [
+        "SHBG|Human|Woman SHBG 40% less",
+        "CYP3A4|Human|Woman SHBG 40% less",
+        "CYP2C9|Human|Woman SHBG 40% less",
+        "ALB|Human|Woman SHBG 40% less"
+      ]
+    },
+    {
+      "Name": "Woman SHBG 40% more",
+      "Seed": 11243912,
+      "OriginData": {
+        "CalculationMethods": [
+          "Body surface area - Mosteller",
+          "SurfaceAreaPlsInt_VAR1"
+        ],
+        "Species": "Human",
+        "Population": "European_ICRP_2002",
+        "Gender": "FEMALE",
+        "Age": {
+          "Value": 30.0,
+          "Unit": "year(s)"
+        }
+      },
+      "ExpressionProfiles": [
+        "SHBG|Human|Woman SHBG 40% more",
+        "CYP3A4|Human|Woman SHBG 40% more",
+        "CYP2C9|Human|Woman SHBG 40% more",
+        "ALB|Human|Woman SHBG 40% more"
+      ]
+    }
+  ],
+  "Populations": [
+    {
+      "Name": "Women",
+      "Seed": 92950625,
+      "Settings": {
+        "NumberOfIndividuals": 18,
+        "ProportionOfFemales": 100,
+        "Age": {
+          "Min": 25.0,
+          "Max": 40.0,
+          "Unit": "year(s)"
+        },
+        "Weight": {
+          "Min": 45.0,
+          "Max": 90.0,
+          "Unit": "kg"
+        },
+        "Height": {
+          "Min": 140.0,
+          "Max": 180.0,
+          "Unit": "cm"
+        },
+        "Individual": {
+          "Name": "Woman",
+          "Seed": 11243912,
+          "OriginData": {
+            "CalculationMethods": [
+              "Body surface area - Mosteller",
+              "SurfaceAreaPlsInt_VAR1"
+            ],
+            "Species": "Human",
+            "Population": "European_ICRP_2002",
+            "Gender": "FEMALE",
+            "Age": {
+              "Value": 30.0,
+              "Unit": "year(s)"
+            }
+          },
+          "ExpressionProfiles": [
+            "CYP3A4|Human|Women",
+            "SHBG|Human|Women",
+            "CYP2C9|Human|Women",
+            "ALB|Human|Women"
+          ]
+        }
+      },
+      "AdvancedParameters": [
+        {
+          "Name": "CYP3A4|Reference concentration",
+          "Seed": 181552656,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 4.32,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|t1/2 (liver)",
+          "Seed": 250536500,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 7.0,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|t1/2 (intestine)",
+          "Seed": 250541515,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 7.0,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|Reference concentration",
+          "Seed": 250572718,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 76.1,
+              "Unit": "nmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 21.5,
+              "Unit": "nmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|Reference concentration",
+          "Seed": 406521578,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 3.84,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (liver)",
+          "Seed": 406521687,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 104.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "ALB|Reference concentration",
+          "Seed": 16955984,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 0.7,
+              "Unit": "mmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.2,
+              "Unit": "mmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (liver)",
+          "Seed": 16960531,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 37.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "ALB|t1/2 (liver)",
+          "Seed": 16962843,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 20.0,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (intestine)",
+          "Seed": 16967843,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (intestine)",
+          "Seed": 16969171,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "ALB|t1/2 (intestine)",
+          "Seed": 16969796,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 20.0,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "Natavio et al 2019 - Class I and II BMI",
+      "Seed": 2703406,
+      "Settings": {
+        "NumberOfIndividuals": 11,
+        "ProportionOfFemales": 100,
+        "Age": {
+          "Min": 18.0,
+          "Max": 31.0,
+          "Unit": "year(s)"
+        },
+        "Weight": {
+          "Min": 81.8,
+          "Max": 108.6,
+          "Unit": "kg"
+        },
+        "BMI": {
+          "Min": 30.0,
+          "Max": 37.2,
+          "Unit": "kg/m²"
+        },
+        "Individual": {
+          "Name": "Woman Class III BMI (above 40)",
+          "Seed": 18233187,
+          "OriginData": {
+            "CalculationMethods": [
+              "SurfaceAreaPlsInt_VAR1",
+              "Body surface area - Mosteller"
+            ],
+            "Species": "Human",
+            "Population": "European_ICRP_2002",
+            "Gender": "FEMALE",
+            "Age": {
+              "Value": 30.0,
+              "Unit": "year(s)"
+            },
+            "Weight": {
+              "Value": 110.0,
+              "Unit": "kg"
+            }
+          },
+          "ExpressionProfiles": [
+            "CYP3A4|Human|Natavio et al 2019 - Class I and II BMI",
+            "CYP2C9|Human|Natavio et al 2019 - Class I and II BMI",
+            "SHBG|Human|Natavio et al 2019 - Class I and II BMI",
+            "ALB|Human|Natavio et al 2019 - Class I and II BMI"
+          ]
+        }
+      },
+      "AdvancedParameters": [
+        {
+          "Name": "CYP3A4|t1/2 (liver)",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 37.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (intestine)",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (liver)",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 104.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|Reference concentration",
+          "Seed": 2713312,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 27.6,
+              "Unit": "nmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.5
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "Bayer Study 19604",
+      "Seed": 7858171,
+      "Settings": {
+        "NumberOfIndividuals": 12,
+        "ProportionOfFemales": 100,
+        "Age": {
+          "Min": 55.0,
+          "Max": 70.0,
+          "Unit": "year(s)"
+        },
+        "Individual": {
+          "Name": "European (P-gp modified, CYP3A4 36 h)",
+          "Seed": 30344955,
+          "OriginData": {
+            "CalculationMethods": [
+              "SurfaceAreaPlsInt_VAR1",
+              "Body surface area - Mosteller"
+            ],
+            "Species": "Human",
+            "Population": "European_ICRP_2002",
+            "Gender": "MALE",
+            "Age": {
+              "Value": 30.0,
+              "Unit": "year(s)"
+            }
+          },
+          "Parameters": [
+            {
+              "Path": "CYP3A4|Ontogeny factor GI",
+              "Value": 0.9741260583
+            },
+            {
+              "Path": "Organism|Liver|EHC continuous fraction",
+              "Value": 1.0
+            }
+          ],
+          "ExpressionProfiles": [
+            "ABCB1|Human|Bayer Study 19604",
+            "CYP3A4|Human|Bayer Study 19604",
+            "AADAC|Human|Bayer Study 19604",
+            "OATP1B1|Human|Bayer Study 19604",
+            "ATP1A2|Human|Bayer Study 19604 - DDI Rifampicin",
+            "CYP2C9|Human|Bayer Study 19604",
+            "SHBG|Human|Bayer Study 19604",
+            "ALB|Human|Bayer Study 19604"
+          ]
+        }
+      },
+      "AdvancedParameters": [
+        {
+          "Name": "CYP3A4|t1/2 (liver)",
+          "Seed": 7858687,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (intestine)",
+          "Seed": 7858687,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (liver)",
+          "Seed": 7858687,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 104.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "AADAC|Reference concentration",
+          "Seed": 7891687,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.4,
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Method": "Assumption",
+                "Description": "Nina Hanke, Sebastian Frechen, Daniel Moj et al. CPT: Pharmacometrics & Systems Pharmacology (2018) https://doi.org/10.1002/psp4.12343"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "ABCB1|Reference concentration",
+          "Seed": 7893218,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.41,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.6,
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Method": "Assumption",
+                "Description": "Nina Hanke, Sebastian Frechen, Daniel Moj et al. CPT: Pharmacometrics & Systems Pharmacology (2018) https://doi.org/10.1002/psp4.12343"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "OATP1B1|Reference concentration",
+          "Seed": 7894875,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.54,
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Method": "Assumption",
+                "Description": "Nina Hanke, Sebastian Frechen, Daniel Moj et al. CPT: Pharmacometrics & Systems Pharmacology (2018) https://doi.org/10.1002/psp4.12343"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "ATP1A2|Reference concentration",
+          "Seed": 7900640,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 0.47661714,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.4,
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Method": "Assumption",
+                "Description": "Nina Hanke, Sebastian Frechen, Daniel Moj et al. CPT: Pharmacometrics & Systems Pharmacology (2018) https://doi.org/10.1002/psp4.12343"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|Reference concentration",
+          "Seed": 8028921,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 60.0,
+              "Unit": "nmol/l",
+              "ValueOrigin": {
+                "Source": "Other",
+                "Method": "InVivo",
+                "Description": "Bayer Study 19604"
+              }
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "Praditpan et al 2017 - Class I and II BMI",
+      "Seed": 2703406,
+      "Settings": {
+        "NumberOfIndividuals": 11,
+        "ProportionOfFemales": 100,
+        "Age": {
+          "Min": 18.0,
+          "Max": 31.0,
+          "Unit": "year(s)"
+        },
+        "Weight": {
+          "Min": 81.8,
+          "Max": 108.6,
+          "Unit": "kg"
+        },
+        "BMI": {
+          "Min": 30.0,
+          "Max": 37.2,
+          "Unit": "kg/m²"
+        },
+        "Individual": {
+          "Name": "Woman Class III BMI (above 40)",
+          "Seed": 18233187,
+          "OriginData": {
+            "CalculationMethods": [
+              "SurfaceAreaPlsInt_VAR1",
+              "Body surface area - Mosteller"
+            ],
+            "Species": "Human",
+            "Population": "European_ICRP_2002",
+            "Gender": "FEMALE",
+            "Age": {
+              "Value": 30.0,
+              "Unit": "year(s)"
+            },
+            "Weight": {
+              "Value": 110.0,
+              "Unit": "kg"
+            }
+          },
+          "ExpressionProfiles": [
+            "CYP3A4|Human|Praditpan et al 2017 - Class I and II BMI",
+            "CYP2C9|Human|Praditpan et al 2017 - Class I and II BMI",
+            "SHBG|Human|Praditpan et al 2017 - Class I and II BMI",
+            "ALB|Human|Praditpan et al 2017 - Class I and II BMI"
+          ]
+        }
+      },
+      "AdvancedParameters": [
+        {
+          "Name": "CYP3A4|Reference concentration",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 4.32,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 1.4,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (liver)",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 37.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (intestine)",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|Reference concentration",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 3.84,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (liver)",
+          "Seed": 2704031,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 104.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|Reference concentration",
+          "Seed": 2713312,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 38.5,
+              "Unit": "nmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.15
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "Healthy women",
+      "Seed": 632939968,
+      "Settings": {
+        "NumberOfIndividuals": 20,
+        "ProportionOfFemales": 100,
+        "Age": {
+          "Min": 18.0,
+          "Max": 30.0,
+          "Unit": "year(s)"
+        },
+        "BMI": {
+          "Min": 20.0,
+          "Max": 24.9,
+          "Unit": "kg/m²"
+        },
+        "Individual": {
+          "Name": "European (P-gp modified, CYP3A4 36 h)",
+          "Seed": 30344955,
+          "OriginData": {
+            "CalculationMethods": [
+              "SurfaceAreaPlsInt_VAR1",
+              "Body surface area - Mosteller"
+            ],
+            "Species": "Human",
+            "Population": "European_ICRP_2002",
+            "Gender": "MALE",
+            "Age": {
+              "Value": 30.0,
+              "Unit": "year(s)"
+            }
+          },
+          "Parameters": [
+            {
+              "Path": "CYP3A4|Ontogeny factor GI",
+              "Value": 0.9741260583
+            },
+            {
+              "Path": "Organism|Liver|EHC continuous fraction",
+              "Value": 1.0
+            }
+          ],
+          "ExpressionProfiles": [
+            "ABCB1|Human|Healthy women",
+            "CYP3A4|Human|Healthy women",
+            "AADAC|Human|Healthy women",
+            "OATP1B1|Human|Healthy women",
+            "ATP1A2|Human|Healthy women",
+            "CYP2C9|Human|Healthy women",
+            "SHBG|Human|Healthy women",
+            "ALB|Human|Healthy women"
+          ]
+        }
+      },
+      "AdvancedParameters": [
+        {
+          "Name": "CYP3A4|t1/2 (liver)",
+          "Seed": 632941125,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (intestine)",
+          "Seed": 632941140,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (liver)",
+          "Seed": 632941140,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 104.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|Reference concentration",
+          "Seed": 633010187,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 60.0,
+              "Unit": "nmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.2
+            }
+          ]
+        },
+        {
+          "Name": "OATP1B1|Reference concentration",
+          "Seed": 633021390,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.54
+            }
+          ]
+        },
+        {
+          "Name": "ATP1A2|Reference concentration",
+          "Seed": 633022046,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 0.47661714,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.4
+            }
+          ]
+        },
+        {
+          "Name": "AADAC|Reference concentration",
+          "Seed": 633022562,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.4
+            }
+          ]
+        },
+        {
+          "Name": "ABCB1|Reference concentration",
+          "Seed": 633023000,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.41,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.6
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "Obese Women",
+      "Seed": 183953171,
+      "Settings": {
+        "NumberOfIndividuals": 20,
+        "ProportionOfFemales": 100,
+        "Age": {
+          "Min": 18.0,
+          "Max": 30.0,
+          "Unit": "year(s)"
+        },
+        "BMI": {
+          "Min": 30.0,
+          "Max": 34.9,
+          "Unit": "kg/m²"
+        },
+        "Individual": {
+          "Name": "European (P-gp modified, CYP3A4 36 h)",
+          "Seed": 30344955,
+          "OriginData": {
+            "CalculationMethods": [
+              "SurfaceAreaPlsInt_VAR1",
+              "Body surface area - Mosteller"
+            ],
+            "Species": "Human",
+            "Population": "European_ICRP_2002",
+            "Gender": "MALE",
+            "Age": {
+              "Value": 30.0,
+              "Unit": "year(s)"
+            }
+          },
+          "Parameters": [
+            {
+              "Path": "CYP3A4|Ontogeny factor GI",
+              "Value": 0.9741260583
+            },
+            {
+              "Path": "Organism|Liver|EHC continuous fraction",
+              "Value": 1.0
+            }
+          ],
+          "ExpressionProfiles": [
+            "ABCB1|Human|Obese Women",
+            "CYP3A4|Human|Obese Women",
+            "AADAC|Human|Obese Women",
+            "OATP1B1|Human|Obese Women",
+            "ATP1A2|Human|Obese Women",
+            "CYP2C9|Human|Obese Women",
+            "SHBG|Human|Obese Women",
+            "ALB|Human|Obese Women"
+          ]
+        }
+      },
+      "AdvancedParameters": [
+        {
+          "Name": "CYP3A4|t1/2 (liver)",
+          "Seed": 183987078,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP3A4|t1/2 (intestine)",
+          "Seed": 183987078,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 23.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "CYP2C9|t1/2 (liver)",
+          "Seed": 183987093,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 104.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "SHBG|Reference concentration",
+          "Seed": 184034078,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 27.6,
+              "Unit": "nmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.5
+            }
+          ]
+        },
+        {
+          "Name": "OATP1B1|Reference concentration",
+          "Seed": 184129640,
+          "DistributionType": "Normal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "Deviation",
+              "Value": 0.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "ATP1A2|Reference concentration",
+          "Seed": 184134062,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 0.47661714,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.0
+            }
+          ]
+        },
+        {
+          "Name": "AADAC|Reference concentration",
+          "Seed": 184163062,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.4
+            }
+          ]
+        },
+        {
+          "Name": "ABCB1|Reference concentration",
+          "Seed": 184169000,
+          "DistributionType": "LogNormal",
+          "Parameters": [
+            {
+              "Name": "Mean",
+              "Value": 1.41,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "GeometricDeviation",
+              "Value": 1.6
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "Compounds": [
+    {
+      "Name": "Levonorgestrel 1",
+      "IsSmallMolecule": true,
+      "Lipophilicity": [
+        {
+          "Name": "logP",
+          "Parameters": [
+            {
+              "Name": "Lipophilicity",
+              "Value": 4.0,
+              "Unit": "Log Units",
+              "ValueOrigin": {
+                "Source": "Database",
+                "Method": "ManualFit"
+              }
+            }
+          ]
+        }
+      ],
+      "FractionUnbound": [
+        {
+          "Name": "fu",
+          "Species": "Human",
+          "Parameters": [
+            {
+              "Name": "Fraction unbound (plasma, reference value)",
+              "Value": 1.0,
+              "ValueOrigin": {
+                "Source": "Other",
+                "Method": "Other",
+                "Description": "Binding kinetics operating in mechanistic mode"
+              }
+            }
+          ]
+        }
+      ],
+      "Solubility": [
+        {
+          "Name": "Estimated FaSSIF",
+          "Parameters": [
+            {
+              "Name": "Solubility at reference pH",
+              "Value": 14.0,
+              "Unit": "mg/l",
+              "ValueOrigin": {
+                "Source": "Other",
+                "Method": "Assumption",
+                "Description": "Biorelevant solubility estimated using Simcyp"
+              }
+            },
+            {
+              "Name": "Reference pH",
+              "Value": 6.5,
+              "ValueOrigin": {
+                "Source": "Other",
+                "Method": "Assumption",
+                "Description": "Biorelevant solubility estimated using Simcyp"
+              }
+            }
+          ]
+        }
+      ],
+      "IntestinalPermeability": [
+        {
+          "Name": "Fitted",
+          "Parameters": [
+            {
+              "Name": "Specific intestinal permeability (transcellular)",
+              "Value": 0.0002,
+              "Unit": "cm/min"
+            }
+          ]
+        }
+      ],
+      "Permeability": [
+        {
+          "Name": "Parameter Estimation",
+          "IsDefault": false,
+          "Parameters": [
+            {
+              "Name": "Permeability",
+              "Value": 0.31,
+              "Unit": "cm/min"
+            }
+          ]
+        }
+      ],
+      "Processes": [
+        {
+          "InternalName": "LiverClearance",
+          "DataSource": "Parameter identification",
+          "Species": "Human",
+          "Parameters": [
+            {
+              "Name": "Body weight",
+              "Value": 60.0,
+              "Unit": "kg",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Hematocrit",
+              "Value": 0.41,
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Fraction unbound (experiment)",
+              "Value": 0.014
+            },
+            {
+              "Name": "Lipophilicity (experiment)",
+              "Value": 3.65,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "Plasma clearance",
+              "Value": 0.1,
+              "Unit": "l/h/kg",
+              "ValueOrigin": {
+                "Source": "ParameterIdentification",
+                "Method": "ParameterIdentification",
+                "Description": "Value updated from 'Parameter Identification 1' on 2019-01-22 13:07"
+              }
+            }
+          ],
+          "Description": "Total hepatic clearance is described as first order process in the liver, which eliminates the compound from plasma. Specific clearance is calculated from plasma clearance as input value. Cliv = 5.79 +/- 2.56 L/h. BW = 60 kg"
+        },
+        {
+          "InternalName": "rCYP450_FirstOrder",
+          "DataSource": "Parameter Identification",
+          "Molecule": "CYP3A4",
+          "Metabolite": "Metabolite",
+          "Parameters": [
+            {
+              "Name": "In vitro CL/recombinant enzyme",
+              "Value": 1.45,
+              "Unit": "µl/min/pmol rec. enzyme",
+              "ValueOrigin": {
+                "Source": "ParameterIdentification"
+              }
+            }
+          ]
+        },
+        {
+          "InternalName": "SpecificBinding",
+          "DataSource": "Qi-Gui & Humpel 1990",
+          "Molecule": "SHBG",
+          "Parameters": [
+            {
+              "Name": "koff",
+              "Value": 17.4,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "Kd",
+              "Value": 0.0005,
+              "Unit": "µM"
+            }
+          ]
+        },
+        {
+          "InternalName": "SpecificBinding",
+          "DataSource": "Bayer report",
+          "Molecule": "ALB",
+          "Parameters": [
+            {
+              "Name": "koff",
+              "Value": 6.5,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "Kd",
+              "Value": 6.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        }
+      ],
+      "CalculationMethods": [
+        "Cellular partition coefficient method - Rodgers and Rowland",
+        "Cellular permeability - PK-Sim Standard"
+      ],
+      "Parameters": [
+        {
+          "Name": "Molecular weight",
+          "Value": 312.44,
+          "Unit": "g/mol"
+        },
+        {
+          "Name": "Density (drug)",
+          "Value": 1.2,
+          "Unit": "g/cm³",
+          "ValueOrigin": {
+            "Id": 32,
+            "Source": "Unknown"
+          }
+        }
+      ]
+    }
+  ],
+  "Formulations": [
+    {
+      "Name": "Microlut",
+      "FormulationType": "Formulation_Tablet_Lint80",
+      "Parameters": [
+        {
+          "Name": "Dissolution time (80% dissolved)",
+          "Value": 30.0,
+          "Unit": "min"
+        },
+        {
+          "Name": "Lag time",
+          "Value": 10.0,
+          "Unit": "min"
+        },
+        {
+          "Name": "Use as suspension",
+          "Value": 0.0
+        }
+      ]
+    },
+    {
+      "Name": "Plan B One Step",
+      "FormulationType": "Formulation_Tablet_Lint80",
+      "Parameters": [
+        {
+          "Name": "Dissolution time (80% dissolved)",
+          "Value": 180.0,
+          "Unit": "min"
+        },
+        {
+          "Name": "Lag time",
+          "Value": 0.0,
+          "Unit": "min"
+        },
+        {
+          "Name": "Use as suspension",
+          "Value": 0.0
+        }
+      ]
+    }
+  ],
+  "Protocols": [
+    {
+      "Name": "PO_0.27",
+      "ApplicationType": "Oral",
+      "DosingInterval": "Single",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.27,
+          "Unit": "mg"
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ]
+    },
+    {
+      "Name": "PO_0.03",
+      "ApplicationType": "Oral",
+      "DosingInterval": "DI_24",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.03,
+          "Unit": "mg"
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 4.0,
+          "Unit": "ml/kg"
+        }
+      ]
+    },
+    {
+      "Name": "IV_0.09",
+      "ApplicationType": "IntravenousBolus",
+      "DosingInterval": "Single",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.09,
+          "Unit": "mg"
+        }
+      ]
+    },
+    {
+      "Name": "PO_0.09",
+      "ApplicationType": "Oral",
+      "DosingInterval": "DI_24",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.09,
+          "Unit": "mg"
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.03 mg 28 days",
+      "ApplicationType": "Oral",
+      "DosingInterval": "DI_24",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.03,
+          "Unit": "mg"
+        },
+        {
+          "Name": "End time",
+          "Value": 29.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.75 mg on day 14th",
+      "DosingInterval": "Single",
+      "Schemas": [
+        {
+          "Name": "Schema 1",
+          "SchemaItems": [
+            {
+              "Name": "Schema Item 1",
+              "ApplicationType": "Oral",
+              "FormulationKey": "Formulation",
+              "Parameters": [
+                {
+                  "Name": "Start time",
+                  "Value": 0.0,
+                  "Unit": "h"
+                },
+                {
+                  "Name": "InputDose",
+                  "Value": 0.75,
+                  "Unit": "mg"
+                },
+                {
+                  "Name": "Volume of water/body weight",
+                  "Value": 3.5,
+                  "Unit": "ml/kg"
+                }
+              ]
+            }
+          ],
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 14.0,
+              "Unit": "day(s)",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 1.0
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        }
+      ],
+      "TimeUnit": "day(s)"
+    },
+    {
+      "Name": "Natavio et al 2019 - Plan B One Step - Normal BMI",
+      "ApplicationType": "Oral",
+      "DosingInterval": "Single",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 1.5,
+          "Unit": "mg"
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.6,
+          "Unit": "ml/kg"
+        }
+      ]
+    },
+    {
+      "Name": "Bayer Study 19604 - Levonorgestrel 0.03 mg single dose day 1",
+      "ApplicationType": "Oral",
+      "DosingInterval": "Single",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.03,
+          "Unit": "mg"
+        },
+        {
+          "Name": "End time",
+          "Value": 8.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ]
+    },
+    {
+      "Name": "LNG_150 ug_21 Days",
+      "ApplicationType": "Oral",
+      "DosingInterval": "DI_24",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h"
+        },
+        {
+          "Name": "InputDose",
+          "Value": 0.15,
+          "Unit": "mg"
+        },
+        {
+          "Name": "End time",
+          "Value": 22.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ]
+    }
+  ],
+  "ObserverSets": [
+    {
+      "Name": "Sum_LNG_species",
+      "Observers": [
+        {
+          "Name": "Sum_LNG_species",
+          "Dimension": "Concentration (molar)",
+          "ContainerCriteria": [
+            {
+              "Tag": "VenousBlood",
+              "Type": "In container"
+            }
+          ],
+          "Formula": {
+            "Name": "Sum_LNG_species",
+            "Formula": "LNG+LNG_ALB+LNG_SHBG",
+            "References": [
+              {
+                "Alias": "LNG",
+                "Dimension": "Concentration (molar)",
+                "Path": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Concentration"
+              },
+              {
+                "Alias": "LNG_ALB",
+                "Dimension": "Concentration (molar)",
+                "Path": "Organism|VenousBlood|Plasma|Levonorgestrel 1-ALB-Bayer report Complex|Concentration"
+              },
+              {
+                "Alias": "LNG_SHBG",
+                "Dimension": "Concentration (molar)",
+                "Path": "Organism|VenousBlood|Plasma|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Concentration"
+              }
+            ],
+            "Dimension": "Concentration (molar)"
+          },
+          "MoleculeList": {
+            "ForAll": false,
+            "MoleculeNamesToInclude": [
+              "Levonorgestrel 1",
+              "Levonorgestrel 1-ALB-Bayer report Complex",
+              "Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex"
+            ]
+          },
+          "Type": "Container"
+        }
+      ]
+    }
+  ],
+  "Events": [
+    {
+      "Name": "Praditpan et al 2017",
+      "Template": "Meal: Standard (Human)",
+      "Parameters": [
+        {
+          "Name": "Meal energy content",
+          "Value": 400.0,
+          "Unit": "cal",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        }
+      ]
+    }
+  ],
+  "Simulations": [
+    {
+      "Name": "LNG 0.09 mg IV - Bayer Study A229",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_IV_0_09 mg",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 18",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 72.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|Liver|Intracellular|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Fraction of dose-Levonorgestrel 1-Liver-Intracellular"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "IV_0.09"
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Vss",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vss",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Cl",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea",
+                "Index": 1
+              },
+              {
+                "Name": "Vd",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vd",
+                "Area": "DataArea",
+                "Index": 2
+              },
+              {
+                "Name": "t1/2",
+                "Dimension": "Time",
+                "Scaling": "Linear",
+                "Unit": "h",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Thalf",
+                "Area": "DataArea",
+                "Index": 3
+              }
+            ],
+            "ShowOutliers": false
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification_SA\nLNG 0.09 mg IV - Bayer Study A229\n2020-07-02 12:19"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-LNG 0.09 mg_IV_mean_SD-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "mean_SD_LNG_IV_0_09 mg",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 18",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1",
+              "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "mean_SD_LNG_IV_0_09 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-mean (ng/L)",
+                "Path": "mean_SD_LNG_IV_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|mean (ng/L)",
+                "CurveOptions": {
+                  "Visible": false,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 18-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 18|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": true
+          },
+          "YAxisSettings": {
+            "AutoRange": true
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 18,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 18,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification_SA\nLNG 0.09 mg IV - Bayer Study A229\n2020-07-02 12:19"
+        }
+      ]
+    },
+    {
+      "Name": "IV",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_IV_0_09 mg"
+      ],
+      "Solver": {
+        "AbsTol": 1E-08,
+        "RelTol": 0.001
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 72.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 76.1,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|Liver|Intracellular|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Fraction of dose-Levonorgestrel 1-Liver-Intracellular"
+      ],
+      "Individual": "Woman",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "IV_0.09"
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "",
+              "Dimension": "Fraction",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "nmol/l",
+              "Dimension": "Concentration (molar)",
+              "Type": "Y2",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Dash",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "mean_SD_LNG_IV_0_09 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-mean (ng/L)",
+              "X": "mean_SD_LNG_IV_0_09 mg|time (h)",
+              "Y": "mean_SD_LNG_IV_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|mean (ng/L)",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#00C0C0",
+                "LegendIndex": 17,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
+            },
+            {
+              "Name": "IV-Levonorgestrel 1-Venous Blood-Plasma-Sum_LNG_species",
+              "X": "Time",
+              "Y": "IV|Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#0000FF",
+                "LegendIndex": 25,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "IV-Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite-Liver-Intracellular-Fraction of dose-Levonorgestrel 1-Liver-Intracellular",
+              "X": "Time",
+              "Y": "IV|Organism|Liver|Intracellular|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Fraction of dose-Levonorgestrel 1-Liver-Intracellular",
+              "CurveOptions": {
+                "Color": "#FF00FF",
+                "LegendIndex": 23
+              }
+            }
+          ],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification_SA\nIV\n2020-07-02 12:15"
+        }
+      ]
+    },
+    {
+      "Name": "Bayer Study 19604 - control Day 1",
+      "Model": "4Comp",
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 72.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 5.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ABCB1|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ABCB1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ABCB1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|Bayer Study 19604 - Levonorgestrel 0.03 mg single dose day 1|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Ontogeny factor GI",
+          "Value": 0.9741260583
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Liver|EHC continuous fraction",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 76.1,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+        "Organism|VenousBlood|Plasma|ATP1A2|Concentration in container",
+        "Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+        "Organism|VenousBlood|Plasma|ALB|Concentration in container"
+      ],
+      "Population": "Bayer Study 19604",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "ABCB1"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "OATP1B1"
+            },
+            {
+              "MoleculeName": "ATP1A2"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "Bayer Study 19604 - Levonorgestrel 0.03 mg single dose day 1",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Total LNG",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Unbound LNG",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+                "QuantityType": "Drug, Observer",
+                "Color": "#FF0000",
+                "Area": "DataArea",
+                "Index": 1
+              },
+              {
+                "Name": "SHBG",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+                "QuantityType": "OtherProtein, Observer",
+                "Color": "#00C000",
+                "Area": "DataArea",
+                "Index": 2
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_04 DEC 2019\nBayer Study 19604 - control Day 1\n2019-12-04 11:06"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.09 mg PO (Microlut) - Bayer Study A53768",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_09 mg",
+        "LNG 0_09 mg_single dose 9",
+        "LNG 0_09 mg_single dose 8",
+        "LNG 0_09 mg_single dose 7",
+        "LNG 0_09 mg_single dose 6",
+        "LNG 0_09 mg_single dose 5",
+        "LNG 0_09 mg_single dose 4",
+        "LNG 0_09 mg_single dose 3",
+        "LNG 0_09 mg_single dose 2",
+        "LNG 0_09 mg_single dose 17",
+        "LNG 0_09 mg_single dose 16",
+        "LNG 0_09 mg_single dose 15",
+        "LNG 0_09 mg_single dose 14",
+        "LNG 0_09 mg_single dose 13",
+        "LNG 0_09 mg_single dose 12",
+        "LNG 0_09 mg_single dose 11",
+        "LNG 0_09 mg_single dose 10",
+        "LNG 0_09 mg_single dose 1",
+        "LNG 0_09 mg_single dose"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 72.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Applications|PO_0.09|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "PO_0.09",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Vss",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vss",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Cl",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "ShowOutliers": false
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.09 mg_PO_mean_SD\n2019-12-03 15:03"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-LNG 0.09 mg_PO_mean_SD-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "mean_SD_LNG_PO_0_09 mg",
+              "LNG 0_09 mg_single dose 9",
+              "LNG 0_09 mg_single dose 8",
+              "LNG 0_09 mg_single dose 7",
+              "LNG 0_09 mg_single dose 6",
+              "LNG 0_09 mg_single dose 5",
+              "LNG 0_09 mg_single dose 4",
+              "LNG 0_09 mg_single dose 3",
+              "LNG 0_09 mg_single dose 2",
+              "LNG 0_09 mg_single dose 17",
+              "LNG 0_09 mg_single dose 16",
+              "LNG 0_09 mg_single dose 15",
+              "LNG 0_09 mg_single dose 14",
+              "LNG 0_09 mg_single dose 13",
+              "LNG 0_09 mg_single dose 12",
+              "LNG 0_09 mg_single dose 11",
+              "LNG 0_09 mg_single dose 10",
+              "LNG 0_09 mg_single dose 1",
+              "LNG 0_09 mg_single dose"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "mean_SD_LNG_PO_0_09 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ng/L)",
+                "Path": "mean_SD_LNG_PO_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/L)",
+                "CurveOptions": {
+                  "Visible": false,
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 9-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column11 ",
+                "Path": "LNG 0_09 mg_single dose 9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column11 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 8-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column10 ",
+                "Path": "LNG 0_09 mg_single dose 8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column10 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 7-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column9 ",
+                "Path": "LNG 0_09 mg_single dose 7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column9 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 6-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column8 ",
+                "Path": "LNG 0_09 mg_single dose 6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column8 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 5-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column7 ",
+                "Path": "LNG 0_09 mg_single dose 5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column7 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 4-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column6 ",
+                "Path": "LNG 0_09 mg_single dose 4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column6 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 3-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column5 ",
+                "Path": "LNG 0_09 mg_single dose 3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column5 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 2-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column4 ",
+                "Path": "LNG 0_09 mg_single dose 2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column4 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 17-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column19 ",
+                "Path": "LNG 0_09 mg_single dose 17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column19 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 16-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column18 ",
+                "Path": "LNG 0_09 mg_single dose 16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column18 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 15-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column17 ",
+                "Path": "LNG 0_09 mg_single dose 15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column17 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 14-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column16 ",
+                "Path": "LNG 0_09 mg_single dose 14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column16 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 13-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column15 ",
+                "Path": "LNG 0_09 mg_single dose 13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column15 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 12-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column14 ",
+                "Path": "LNG 0_09 mg_single dose 12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column14 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 11-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column13 ",
+                "Path": "LNG 0_09 mg_single dose 11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column13 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 10-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column12 ",
+                "Path": "LNG 0_09 mg_single dose 10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column12 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column3 ",
+                "Path": "LNG 0_09 mg_single dose 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column3 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_09 mg_single dose-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column2 ",
+                "Path": "LNG 0_09 mg_single dose|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column2 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "Min": -1.3103469775,
+            "Max": 73.3827264457,
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "Min": 0.0226926754,
+            "Max": 56.187704474,
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 18,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 18,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.09 mg_PO_mean_SD\n2019-12-03 15:03"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.03 mg PO single dose - Bayer Study A53768",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_03 mg",
+        "mean_SD_LNG_PO_0_03mg_SS_DAY_01",
+        "LNG 0_03 mg_SS_1st day 9",
+        "LNG 0_03 mg_SS_1st day 8",
+        "LNG 0_03 mg_SS_1st day 7",
+        "LNG 0_03 mg_SS_1st day 6",
+        "LNG 0_03 mg_SS_1st day 5",
+        "LNG 0_03 mg_SS_1st day 4",
+        "LNG 0_03 mg_SS_1st day 3",
+        "LNG 0_03 mg_SS_1st day 20",
+        "LNG 0_03 mg_SS_1st day 2",
+        "LNG 0_03 mg_SS_1st day 19",
+        "LNG 0_03 mg_SS_1st day 18",
+        "LNG 0_03 mg_SS_1st day 17",
+        "LNG 0_03 mg_SS_1st day 16",
+        "LNG 0_03 mg_SS_1st day 15",
+        "LNG 0_03 mg_SS_1st day 14",
+        "LNG 0_03 mg_SS_1st day 13",
+        "LNG 0_03 mg_SS_1st day 12",
+        "LNG 0_03 mg_SS_1st day 11",
+        "LNG 0_03 mg_SS_1st day 10",
+        "LNG 0_03 mg_SS_1st day 1",
+        "LNG 0_03 mg_SS_1st day"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Applications|PO_0.03|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 4.0,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "PO_0.03",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-LNG 0.09 mg_PO_mean_SD-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "mean_SD_LNG_PO_0_03 mg",
+              "mean_SD_LNG_PO_0_03mg_SS_DAY_01",
+              "LNG 0_03 mg_SS_1st day 9",
+              "LNG 0_03 mg_SS_1st day 8",
+              "LNG 0_03 mg_SS_1st day 7",
+              "LNG 0_03 mg_SS_1st day 6",
+              "LNG 0_03 mg_SS_1st day 5",
+              "LNG 0_03 mg_SS_1st day 4",
+              "LNG 0_03 mg_SS_1st day 3",
+              "LNG 0_03 mg_SS_1st day 20",
+              "LNG 0_03 mg_SS_1st day 2",
+              "LNG 0_03 mg_SS_1st day 19",
+              "LNG 0_03 mg_SS_1st day 18",
+              "LNG 0_03 mg_SS_1st day 17",
+              "LNG 0_03 mg_SS_1st day 16",
+              "LNG 0_03 mg_SS_1st day 15",
+              "LNG 0_03 mg_SS_1st day 14",
+              "LNG 0_03 mg_SS_1st day 13",
+              "LNG 0_03 mg_SS_1st day 12",
+              "LNG 0_03 mg_SS_1st day 11",
+              "LNG 0_03 mg_SS_1st day 10",
+              "LNG 0_03 mg_SS_1st day 1",
+              "LNG 0_03 mg_SS_1st day"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "mean_SD_LNG_PO_0_03 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ug/L)",
+                "Path": "mean_SD_LNG_PO_0_03 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)",
+                "CurveOptions": {
+                  "Visible": false,
+                  "Color": "#FFFFFF",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "mean_SD_LNG_PO_0_03mg_SS_DAY_01-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ug/L)",
+                "Path": "mean_SD_LNG_PO_0_03mg_SS_DAY_01|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)",
+                "CurveOptions": {
+                  "Visible": false,
+                  "Color": "#FFFFFF",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 9-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column11 ",
+                "Path": "LNG 0_03 mg_SS_1st day 9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column11 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 8-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column10 ",
+                "Path": "LNG 0_03 mg_SS_1st day 8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column10 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 7-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column9 ",
+                "Path": "LNG 0_03 mg_SS_1st day 7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column9 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 6-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column8 ",
+                "Path": "LNG 0_03 mg_SS_1st day 6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column8 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 5-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column7 ",
+                "Path": "LNG 0_03 mg_SS_1st day 5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column7 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 4-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column6 ",
+                "Path": "LNG 0_03 mg_SS_1st day 4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column6 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 3-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column5 ",
+                "Path": "LNG 0_03 mg_SS_1st day 3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column5 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 20-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column22 ",
+                "Path": "LNG 0_03 mg_SS_1st day 20|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column22 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 2-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column4 ",
+                "Path": "LNG 0_03 mg_SS_1st day 2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column4 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 19-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column21 ",
+                "Path": "LNG 0_03 mg_SS_1st day 19|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column21 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 18-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column20 ",
+                "Path": "LNG 0_03 mg_SS_1st day 18|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column20 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 17-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column19 ",
+                "Path": "LNG 0_03 mg_SS_1st day 17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column19 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 16-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column18 ",
+                "Path": "LNG 0_03 mg_SS_1st day 16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column18 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 15-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column17 ",
+                "Path": "LNG 0_03 mg_SS_1st day 15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column17 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 14-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column16 ",
+                "Path": "LNG 0_03 mg_SS_1st day 14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column16 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 13-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column15 ",
+                "Path": "LNG 0_03 mg_SS_1st day 13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column15 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 12-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column14 ",
+                "Path": "LNG 0_03 mg_SS_1st day 12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column14 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 11-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column13 ",
+                "Path": "LNG 0_03 mg_SS_1st day 11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column13 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 10-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column12 ",
+                "Path": "LNG 0_03 mg_SS_1st day 10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column12 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day 1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column3 ",
+                "Path": "LNG 0_03 mg_SS_1st day 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column3 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "LNG 0_03 mg_SS_1st day-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Column2 ",
+                "Path": "LNG 0_03 mg_SS_1st day|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column2 ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "Min": -1.1229753722,
+            "Max": 24.4572348264,
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "Min": 0.0861291785,
+            "Max": 4.961586432,
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 18,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 18,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.03 mg_PO_mean_SD\n2019-12-03 15:55"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.27 mg PO single dose - Bayer Study A53768",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_27 mg",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet1",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet10",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet11",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet12",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet13",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet14",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet15",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet16",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet17",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet18",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet2",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet3",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet4",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet5",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet6",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet7",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet8",
+        "ocp_dataset_V2_KW_A229_0.27mg.Sheet9"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 72.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Applications|PO_0.27|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "PO_0.27",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Vss",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vss",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Cl",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "ShowOutliers": false
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.27 mg_PO_mean_SD\n2019-12-03 16:00"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-LNG 0.09 mg_PO_mean_SD-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "mean_SD_LNG_PO_0_27 mg",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet1",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet10",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet11",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet12",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet13",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet14",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet15",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet16",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet17",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet18",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet2",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet3",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet4",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet5",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet6",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet7",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet8",
+              "ocp_dataset_V2_KW_A229_0.27mg.Sheet9"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "mean_SD_LNG_PO_0_27 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ng/L)",
+                "Path": "mean_SD_LNG_PO_0_27 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/L)",
+                "CurveOptions": {
+                  "Visible": false,
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet1-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet10-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet11-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet12-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet13-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet14-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet15-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet16-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet17-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet18-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet18|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet2-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet3-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet4-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet5-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet6-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet7-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet8-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "ocp_dataset_V2_KW_A229_0.27mg.Sheet9-Levonorgestrel 1-Peripheral Venous Blood-Plasma-PK_VALUE ",
+                "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE ",
+                "CurveOptions": {
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "Min": -1.0714389853,
+            "Max": 73.2536612086,
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "Min": 0.1855214368,
+            "Max": 43.3375304694,
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 18,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 18,
+              "FontFamilyName": "Times New Roman",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.27 mg_PO_mean_SD\n2019-12-03 16:00"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.03 mg PO multiple doses - Bayer Study A53768",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_03 mg",
+        "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 29.0,
+              "Unit": "day(s)",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_10|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_11|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_12|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_13|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_14|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_15|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_16|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_17|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_18|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_19|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_20|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_21|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_22|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_23|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_24|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_25|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_26|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_27|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_28|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_29|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_8|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG 0.03 mg 28 days|Microlut|Application_9|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "LNG 0.03 mg 28 days",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Vss",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vss",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Cl",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "ShowOutliers": false
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.03 mg_PO_mean_SD_SS after 28 days\n2019-12-03 15:58"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-LNG 0.09 mg_PO_mean_SD-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "mean_SD_LNG_PO_0_03 mg",
+              "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "mean_SD_LNG_PO_0_03 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ug/L)",
+                "Path": "mean_SD_LNG_PO_0_03 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)",
+                "CurveOptions": {
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ug/L)",
+                "Path": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)",
+                "CurveOptions": {
+                  "Color": "#8064A2",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": true
+          },
+          "YAxisSettings": {
+            "AutoRange": true
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.03 mg_PO_mean_SD_SS after 28 days\n2019-12-03 15:58"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.75 mg population",
+      "Model": "4Comp",
+      "Solver": {
+        "AbsTol": 1E-12,
+        "RelTol": 1E-11
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "End time",
+              "Value": 0.0833333333,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0833333333,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "End time",
+              "Value": 14.5,
+              "Unit": "day(s)",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|LNG 0.75 mg on day 14th|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.00039687350455
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP2C9|Relative expression",
+          "Value": 4.5940341362E-05
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0018822778753
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP2C9|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.0002131121391
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP2C9|Relative expression",
+          "Value": 0.1199553358
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 76.1,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|Relative expression in plasma",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Individual": "Woman",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "LNG 0.75 mg on day 14th",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "µmol/l",
+              "Dimension": "Concentration (molar)",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "LNG 0.75 mg population-Levonorgestrel 1-Venous Blood-Plasma-Sum_LNG_species",
+              "X": "Time",
+              "Y": "LNG 0.75 mg population|Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 1
+              }
+            }
+          ],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_03 DEC 2019\nLNG 0.75 mg population\n2019-12-03 16:04"
+        }
+      ]
+    },
+    {
+      "Name": "Natavio et al 2019 - Class I and II BMI",
+      "Model": "4Comp",
+      "ObservedData": [
+        "natavio2019_Class I and II BMI digitized",
+        "edelman2016_unbound LNG"
+      ],
+      "Solver": {
+        "AbsTol": 1E-12,
+        "RelTol": 1E-11
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.3,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 96.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|Natavio et al 2019 - Plan B One Step - Normal BMI|Plan B One Step|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.6,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 27.6,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+        "Organism|VenousBlood|Plasma|ALB|Concentration in container",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Natavio et al 2019 - Class I and II BMI",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "Natavio et al 2019 - Plan B One Step - Normal BMI",
+            "Formulations": [
+              {
+                "Name": "Plan B One Step",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Cl/F",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Vss/F",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+                "QuantityType": "OtherProtein, Observer",
+                "PKParameter": "Vss",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "ShowOutliers": true
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nNatavio et al 2019 - Class I and II BMI\n2020-01-28 12:22"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Concentration-Natavio et al 2019 - Class I and II BMI-Levonorgestrel 1-Organism-Plasma Unbound-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "nmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea",
+                "Index": 1
+              },
+              {
+                "Name": "Sum_LNG_species-Natavio et al 2019 - Class I and II BMI-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "µmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "natavio2019_Class I and II BMI digitized",
+              "edelman2016_unbound LNG"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "natavio2019_Class I and II BMI digitized-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ng/mL)",
+                "Path": "natavio2019_Class I and II BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)",
+                "CurveOptions": {
+                  "Color": "#000000",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Caption": "edelman2016_unbound LNG-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc",
+                "Path": "edelman2016_unbound LNG|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc",
+                "CurveOptions": {
+                  "Color": "#000000",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "Min": -0.4310416667,
+            "Max": 96.5898177083,
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "Min": 0.6711058156,
+            "Max": 43.9356946048,
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 20,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 32,
+              "FontFamilyName": "Times New Roman",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nNatavio et al 2019 - Class I and II BMI\n2020-01-28 12:22"
+        }
+      ]
+    },
+    {
+      "Name": "Praditpan et al 2017 - Normal BMI",
+      "Model": "4Comp",
+      "ObservedData": [
+        "praditpan2017_normal BMI digitized"
+      ],
+      "Solver": {
+        "AbsTol": 1E-12,
+        "RelTol": 1E-11
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 48.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Applications|Natavio et al 2019 - Plan B One Step - Normal BMI|Plan B One Step|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.6,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "Natavio et al 2019 - Plan B One Step - Normal BMI",
+            "Formulations": [
+              {
+                "Name": "Plan B One Step",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "Events": [
+        {
+          "Name": "Praditpan et al 2017",
+          "StartTime": {
+            "Value": 0.0,
+            "Unit": "h"
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-Praditpan et al 2017 - Normal BMI-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "ng/ml",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "praditpan2017_normal BMI digitized"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "praditpan2017_normal BMI digitized-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ng/mL)",
+                "Path": "praditpan2017_normal BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)",
+                "CurveOptions": {
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": true
+          },
+          "YAxisSettings": {
+            "AutoRange": true
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_04 DEC 2019\nPraditpan et al 2017 - Normal BMI\n2019-12-04 15:05"
+        },
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Cl/F",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Vd/F",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vd",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "ShowOutliers": true
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_04 DEC 2019\nPraditpan et al 2017 - Normal BMI\n2019-12-04 15:05"
+        }
+      ]
+    },
+    {
+      "Name": "Praditpan et al 2017 - Class I and II BMI",
+      "Model": "4Comp",
+      "ObservedData": [
+        "praditpan2017_Class I and II BMI digitized"
+      ],
+      "Solver": {
+        "AbsTol": 1E-12,
+        "RelTol": 1E-11
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 48.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|Natavio et al 2019 - Plan B One Step - Normal BMI|Plan B One Step|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.6,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 27.6,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species"
+      ],
+      "Population": "Praditpan et al 2017 - Class I and II BMI",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "Natavio et al 2019 - Plan B One Step - Normal BMI",
+            "Formulations": [
+              {
+                "Name": "Plan B One Step",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "Events": [
+        {
+          "Name": "Praditpan et al 2017",
+          "StartTime": {
+            "Value": 0.0,
+            "Unit": "h"
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-Praditpan et al 2017 - Normal BMI-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "ng/ml",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "praditpan2017_Class I and II BMI digitized"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "praditpan2017_Class I and II BMI digitized-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ng/mL)",
+                "Path": "praditpan2017_Class I and II BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)",
+                "CurveOptions": {
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": true
+          },
+          "YAxisSettings": {
+            "AutoRange": true
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "LNG_3.0_04 DEC 2019\nPraditpan et al 2017 - Class I and II BMI\n2019-12-04 15:01"
+        }
+      ]
+    },
+    {
+      "Name": "Natavio et al 2019 - Normal BMI",
+      "Model": "4Comp",
+      "ObservedData": [
+        "natavio2019_normal BMI digitized"
+      ],
+      "Solver": {
+        "AbsTol": 1E-12,
+        "RelTol": 1E-11
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 96.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Applications|Natavio et al 2019 - Plan B One Step - Normal BMI|Plan B One Step|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.6,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "Natavio et al 2019 - Plan B One Step - Normal BMI",
+            "Formulations": [
+              {
+                "Name": "Plan B One Step",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Cl/F",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea"
+              }
+            ],
+            "ShowOutliers": true
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nNatavio et al 2019 - Normal BMI\n2020-01-28 12:17"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-Natavio et al 2019 - Normal BMI-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "ng/ml",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Concentration-Natavio et al 2019 - Normal BMI-Levonorgestrel 1-Organism-Plasma Unbound-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Log",
+                "Unit": "ng/ml",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "natavio2019_normal BMI digitized"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "natavio2019_normal BMI digitized-Levonorgestrel 1-Peripheral Venous Blood-Plasma-Conc (ng/mL)",
+                "Path": "natavio2019_normal BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)",
+                "CurveOptions": {
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": true
+          },
+          "YAxisSettings": {
+            "AutoRange": true
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nNatavio et al 2019 - Normal BMI\n2020-01-28 12:17"
+        },
+        {
+          "Type": "Scatter",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Organism-BMI",
+                "Dimension": "BMI",
+                "Scaling": "Linear",
+                "Unit": "kg/m²",
+                "ParameterPath": "Organism|BMI",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Concentration-Natavio et al 2019 - Normal BMI-Levonorgestrel 1-Organism-Plasma Unbound-Venous Blood|AUC_inf",
+                "Dimension": "AUC (molar)",
+                "Scaling": "Linear",
+                "Unit": "ng*h/ml",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "AUC_inf",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Scatter Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nNatavio et al 2019 - Normal BMI\n2020-01-28 18:37"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.09 mg IV - Bayer Study A229 fmCYP3A4",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_IV_0_09 mg"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 72.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|Liver|Intracellular|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Fraction of dose-Levonorgestrel 1-Liver-Intracellular",
+        "Organism|Liver|Intracellular|Levonorgestrel 1-ALB-Bayer report Complex|Fraction of dose-Levonorgestrel 1-Liver-Intracellular"
+      ],
+      "Population": "Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "IV_0.09"
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "BoxWhisker",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Vss",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vss",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Cl",
+                "Dimension": "Flow per weight",
+                "Scaling": "Linear",
+                "Unit": "l/h/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "CL",
+                "Area": "DataArea",
+                "Index": 1
+              },
+              {
+                "Name": "Vd",
+                "Dimension": "Volume per body weight",
+                "Scaling": "Linear",
+                "Unit": "l/kg",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Vd",
+                "Area": "DataArea",
+                "Index": 2
+              },
+              {
+                "Name": "t1/2",
+                "Dimension": "Time",
+                "Scaling": "Linear",
+                "Unit": "h",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "PKParameter": "Thalf",
+                "Area": "DataArea",
+                "Index": 3
+              }
+            ],
+            "ShowOutliers": false
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            },
+            {
+              "AutoRange": false
+            }
+          ],
+          "Name": "Box Whisker Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nLNG 0.09 mg IV - Bayer Study A229 fmCYP3A4\n2020-01-07 12:43"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Fraction of dose-Levonorgestrel 1-Liver-Intracellular-LNG 0.09 mg IV - Bayer Study A229 fmCYP3A4-Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite-Organism-Intracellular-Liver",
+                "Dimension": "Fraction",
+                "Scaling": "Linear",
+                "QuantityPath": "Organism|Liver|Intracellular|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Fraction of dose-Levonorgestrel 1-Liver-Intracellular",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "ObservedDataCollection": {
+            "ObservedData": [
+              "mean_SD_LNG_IV_0_09 mg"
+            ],
+            "ApplyGrouping": false,
+            "CurveOptions": [
+              {
+                "Caption": "mean_SD_LNG_IV_0_09 mg-Levonorgestrel 1-Peripheral Venous Blood-Plasma-mean (ng/L)",
+                "Path": "mean_SD_LNG_IV_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|mean (ng/L)",
+                "CurveOptions": {
+                  "Visible": false,
+                  "Color": "#0000C0",
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": true
+          },
+          "YAxisSettings": {
+            "AutoRange": true
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "None",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification\nLNG 0.09 mg IV - Bayer Study A229 fmCYP3A4\n2020-01-07 12:43"
+        }
+      ]
+    },
+    {
+      "Name": "DDI_LNG150ug_21days",
+      "Model": "4Comp",
+      "Solver": {
+        "AbsTol": 1E-15,
+        "RelTol": 1E-15
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 2.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 22.0,
+              "Unit": "day(s)",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ABCB1|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ABCB1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ABCB1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_10|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_11|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_12|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_13|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_14|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_15|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_16|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_17|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_18|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_19|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_20|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_21|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_22|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_8|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_9|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Ontogeny factor GI",
+          "Value": 0.9741260583
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Liver|EHC continuous fraction",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 76.1,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound"
+      ],
+      "Population": "Healthy women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "ABCB1"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "OATP1B1"
+            },
+            {
+              "MoleculeName": "ATP1A2"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "LNG_150 ug_21 Days",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Total fraction of dose-Levonorgestrel 1-DDI_LNG150ug_21days-Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite--Organism",
+                "Dimension": "Fraction",
+                "Scaling": "Linear",
+                "QuantityPath": "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_updated on 07072020\nDDI_LNG150ug_21days\n2020-08-25 20:08"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-DDI_LNG150ug_21days-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Linear",
+                "Unit": "µmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis 1",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_updated on 07072020\nDDI_LNG150ug_21days\n2020-08-25 20:34"
+        },
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Concentration-DDI_LNG150ug_21days-Levonorgestrel 1-Organism-Plasma Unbound-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Linear",
+                "Unit": "µmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis 2",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_updated on 07072020\nDDI_LNG150ug_21days\n2020-08-25 20:34"
+        }
+      ]
+    },
+    {
+      "Name": "DDI_LNG150ug_21days_Obe",
+      "Model": "4Comp",
+      "Solver": {
+        "AbsTol": 1E-15,
+        "RelTol": 1E-15
+      },
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 2.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 22.0,
+              "Unit": "day(s)",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 4.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ABCB1|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ABCB1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ABCB1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_10|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_11|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_12|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_13|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_14|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_15|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_16|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_17|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_18|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_19|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_20|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_21|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_22|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_8|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|LNG_150 ug_21 Days|Microlut|Application_9|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.47661714,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Ontogeny factor GI",
+          "Value": 0.9741260583
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Liver|EHC continuous fraction",
+          "Value": 1.0
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 76.1,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|Levonorgestrel 1-CYP3A4-Parameter Identification Metabolite|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|Levonorgestrel 1-ALB-Bayer report Complex|Total fraction of dose-Levonorgestrel 1",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound"
+      ],
+      "Population": "Obese Women",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "MoleculeName": "ABCB1"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "OATP1B1"
+            },
+            {
+              "MoleculeName": "ATP1A2"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "LNG_150 ug_21 Days",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "PopulationAnalyses": [
+        {
+          "Type": "TimeProfile",
+          "Analysis": {
+            "Fields": [
+              {
+                "Name": "Sum_LNG_species-DDI_LNG150ug_21days_Obe-Levonorgestrel 1-Organism-Plasma-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Linear",
+                "Unit": "µmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+                "QuantityType": "Drug, Observer",
+                "Color": "#000000",
+                "Area": "DataArea"
+              },
+              {
+                "Name": "Concentration-DDI_LNG150ug_21days_Obe-Levonorgestrel 1-Organism-Plasma Unbound-Venous Blood",
+                "Dimension": "Concentration (molar)",
+                "Scaling": "Linear",
+                "Unit": "µmol/l",
+                "QuantityPath": "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+                "QuantityType": "Drug, Observer",
+                "Color": "#FF0000",
+                "Area": "DataArea",
+                "Index": 1
+              }
+            ],
+            "Statistics": [
+              {
+                "Id": "ArithmeticMean",
+                "LineStyle": "Solid"
+              },
+              {
+                "Id": "Range90",
+                "LineStyle": "Solid"
+              }
+            ]
+          },
+          "XAxisSettings": {
+            "AutoRange": false
+          },
+          "YAxisSettings": {
+            "AutoRange": false
+          },
+          "SecondaryYAxisSettings": [],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_updated on 07072020\nDDI_LNG150ug_21days_Obe\n2020-08-26 21:14"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.03 mg standard",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_03 mg",
+        "mean_SD_LNG_PO_0_03mg_SS_DAY_01"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|PO_0.03|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 4.0,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 76.1,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Concentration in container",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1-ALB-Bayer report Complex|Concentration in container",
+        "Organism|VenousBlood|Plasma|SHBG|Concentration in container"
+      ],
+      "Individual": "Woman",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "PO_0.03",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "µmol/l",
+              "Dimension": "Concentration (mass)",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "",
+              "Type": "Y2",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Dash",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "LNG 0.03 mg standard-Levonorgestrel 1-Venous Blood-Plasma-Sum_LNG_species",
+              "X": "Time",
+              "Y": "LNG 0.03 mg standard|Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+              "CurveOptions": {
+                "Color": "#FF00FF",
+                "LegendIndex": 11
+              }
+            },
+            {
+              "Name": "LNG 0.03 mg standard-Levonorgestrel 1-Venous Blood-Plasma Unbound-Concentration",
+              "X": "Time",
+              "Y": "LNG 0.03 mg standard|Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+              "CurveOptions": {
+                "Color": "#0000FF",
+                "LegendIndex": 13
+              }
+            },
+            {
+              "Name": "LNG 0.03 mg standard-SHBG-Venous Blood-Plasma-Concentration",
+              "X": "Time",
+              "Y": "LNG 0.03 mg standard|Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 12
+              }
+            }
+          ],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification_SA\nLNG 0.03 mg standard\n2020-06-29 13:58"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.03 mg 40% less",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_03 mg",
+        "mean_SD_LNG_PO_0_03mg_SS_DAY_01"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|PO_0.03|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 4.0,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 45.66,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Concentration in container",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1-ALB-Bayer report Complex|Concentration in container",
+        "Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+        "Organism|VenousBlood|Plasma|ALB|Concentration in container"
+      ],
+      "Individual": "Woman SHBG 40% less",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "PO_0.03",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "µmol/l",
+              "Dimension": "Concentration (mass)",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "",
+              "Type": "Y2",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Dash",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "LNG 0.03 mg 40% less-SHBG-Venous Blood-Plasma-Concentration",
+              "X": "Time",
+              "Y": "LNG 0.03 mg 40% less|Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+              "CurveOptions": {
+                "Color": "#0000FF",
+                "LegendIndex": 13,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "LNG 0.03 mg 40% less-Levonorgestrel 1-Venous Blood-Plasma-Sum_LNG_species",
+              "X": "Time",
+              "Y": "LNG 0.03 mg 40% less|Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+              "CurveOptions": {
+                "Color": "#FF00FF",
+                "LegendIndex": 11,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "LNG 0.03 mg 40% less-Levonorgestrel 1-Venous Blood-Plasma Unbound-Concentration",
+              "X": "Time",
+              "Y": "LNG 0.03 mg 40% less|Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 12,
+                "LineStyle": "Dash"
+              }
+            }
+          ],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification_SA\nLNG 0.03 mg 40% less\n2020-06-29 14:02"
+        }
+      ]
+    },
+    {
+      "Name": "LNG 0.03 mg 40% more",
+      "Model": "4Comp",
+      "ObservedData": [
+        "mean_SD_LNG_PO_0_03 mg",
+        "mean_SD_LNG_PO_0_03mg_SS_DAY_01"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.08,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "End time",
+              "Value": 1.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 2.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 1.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "ALB|Reference concentration",
+          "Value": 0.7,
+          "Unit": "mmol/l",
+          "ValueOrigin": {
+            "Source": "Publication",
+            "Method": "InVivo",
+            "Description": "Qi-Gui & Humpel 1990"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (intestine)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ALB|t1/2 (liver)",
+          "Value": 20.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Applications|PO_0.03|Microlut|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 4.0,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "CYP2C9|Reference concentration",
+          "Value": 3.84,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP2C9|t1/2 (liver)",
+          "Value": 104.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 37.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "SHBG|Reference concentration",
+          "Value": 106.54,
+          "Unit": "nmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (intestine)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "SHBG|t1/2 (liver)",
+          "Value": 7.0,
+          "Unit": "day(s)",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "Undefined Liver|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Undefined Liver|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1-SHBG-Qi-Gui & Humpel 1990 Complex|Concentration in container",
+        "Organism|VenousBlood|Plasma|Levonorgestrel 1-ALB-Bayer report Complex|Concentration in container",
+        "Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+        "Organism|VenousBlood|Plasma|ALB|Concentration in container"
+      ],
+      "Individual": "Woman SHBG 40% more",
+      "Compounds": [
+        {
+          "Name": "Levonorgestrel 1",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Calculated",
+              "GroupName": "COMPOUND_PERMEABILITY"
+            },
+            {
+              "AlternativeName": "Fitted",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "Name": "CYP3A4-Parameter Identification",
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "Total Hepatic Clearance-Parameter identification",
+              "SystemicProcessType": "Hepatic"
+            },
+            {
+              "Name": "SHBG-Qi-Gui & Humpel 1990",
+              "MoleculeName": "SHBG"
+            },
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "MoleculeName": "CYP2C9"
+            },
+            {
+              "Name": "ALB-Bayer report",
+              "MoleculeName": "ALB"
+            }
+          ],
+          "Protocol": {
+            "Name": "PO_0.03",
+            "Formulations": [
+              {
+                "Name": "Microlut",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Sum_LNG_species"
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "µmol/l",
+              "Dimension": "Concentration (mass)",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "",
+              "Type": "Y2",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Dash",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "LNG 0.03 mg 40% more-SHBG-Venous Blood-Plasma-Concentration",
+              "X": "Time",
+              "Y": "LNG 0.03 mg 40% more|Organism|VenousBlood|Plasma|SHBG|Concentration in container",
+              "CurveOptions": {
+                "Color": "#0000FF",
+                "LegendIndex": 13,
+                "LineStyle": "Dot"
+              }
+            },
+            {
+              "Name": "LNG 0.03 mg 40% more-Levonorgestrel 1-Venous Blood-Plasma-Sum_LNG_species",
+              "X": "Time",
+              "Y": "LNG 0.03 mg 40% more|Organism|VenousBlood|Plasma|Levonorgestrel 1|Sum_LNG_species",
+              "CurveOptions": {
+                "Color": "#FF00FF",
+                "LegendIndex": 11,
+                "LineStyle": "Dot"
+              }
+            },
+            {
+              "Name": "LNG 0.03 mg 40% more-Levonorgestrel 1-Venous Blood-Plasma Unbound-Concentration",
+              "X": "Time",
+              "Y": "LNG 0.03 mg 40% more|Organism|VenousBlood|Plasma|Levonorgestrel 1|Plasma Unbound",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 12,
+                "LineStyle": "Dot"
+              }
+            }
+          ],
+          "Name": "Time Profile Analysis",
+          "FontAndSize": {
+            "Fonts": {
+              "AxisSize": 10,
+              "LegendSize": 8,
+              "TitleSize": 16,
+              "DescriptionSize": 12,
+              "OriginSize": 8,
+              "FontFamilyName": "Microsoft Sans Serif",
+              "WatermarkSize": 32
+            }
+          },
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "RightInside",
+            "BackColor": "#00FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Lenorgestrel PBPK model_development and verification_SA\nLNG 0.03 mg 40% more\n2020-06-29 14:06"
+        }
+      ]
+    }
+  ],
+  "ObservedData": [
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00353,
+            0.00353,
+            0.00387,
+            0.00320000015,
+            0.00308,
+            0.0025,
+            0.00187999988,
+            0.00149,
+            0.00126,
+            0.00107,
+            0.00076,
+            0.00059,
+            0.00061,
+            0.00037,
+            0.00026,
+            0.00017,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.53,
+          0.75,
+          1.0,
+          1.63,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet2",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet2",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00279,
+            0.00158,
+            0.00214,
+            0.00133,
+            0.00129,
+            0.00117,
+            0.00088,
+            0.00077,
+            0.00052,
+            0.000299999985,
+            0.000200000009,
+            0.00018,
+            0.00013
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 1|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 2",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet3",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet3",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00596,
+            0.00423,
+            0.00471,
+            0.00411999971,
+            0.00359,
+            0.00298,
+            0.00228,
+            0.00183000008,
+            0.0014,
+            0.00127,
+            0.00096,
+            0.00064,
+            0.00061,
+            0.00036,
+            0.00023,
+            0.000200000009
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 2|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 3",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet4",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet4",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00419,
+            0.00345,
+            0.00343,
+            0.00289000012,
+            0.00276,
+            0.00266,
+            0.00177000009,
+            0.00158,
+            0.00143000006,
+            0.00105,
+            0.00079,
+            0.00061,
+            0.00055,
+            0.00038,
+            0.000249999983,
+            0.000249999983,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 3|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 4",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet5",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet5",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00227,
+            0.00169000006,
+            0.00162,
+            0.00147,
+            0.00148,
+            0.00137,
+            0.00105,
+            0.00085,
+            0.00054,
+            0.00031,
+            0.00024,
+            0.00014,
+            0.00012,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 4|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.08,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 5",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet6",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet6",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00421,
+            0.00315,
+            0.00278,
+            0.00227,
+            0.00198,
+            0.00162,
+            0.00146,
+            0.00098,
+            0.00069,
+            0.000499999966,
+            0.00031,
+            0.00027,
+            0.00027,
+            0.00019,
+            9E-05,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 5|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 6",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet7",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet7",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00317000016,
+            0.00266,
+            0.00208,
+            0.00226,
+            0.00199,
+            0.00176,
+            0.00143000006,
+            0.00126,
+            0.00082,
+            0.00063,
+            0.00041,
+            0.000299999985,
+            0.00024,
+            0.00014,
+            9E-05,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 6|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 7",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet8",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet8",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00604,
+            0.00401,
+            0.00414,
+            0.00313,
+            0.00265,
+            0.00233,
+            0.00186000008,
+            0.00134,
+            0.00113,
+            0.00088,
+            0.00062,
+            0.000529999961,
+            0.000499999966,
+            0.00029,
+            0.00023,
+            0.00016,
+            8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 7|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 8",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet9",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet9",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00625,
+            0.00476,
+            0.00368,
+            0.00319,
+            0.00307,
+            0.00275,
+            0.00239999988,
+            0.00173,
+            0.00133,
+            0.00093999994,
+            0.00061,
+            0.00056,
+            0.00057,
+            0.000299999985,
+            0.000200000009,
+            0.00012
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 8|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 9",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet10",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet10",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0069,
+            0.006,
+            0.00459,
+            0.00355,
+            0.00349,
+            0.0031,
+            0.0025,
+            0.00204,
+            0.00127,
+            0.00096,
+            0.00071,
+            0.00065,
+            0.00068,
+            0.00035,
+            0.00029,
+            0.00019,
+            0.00013
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 9|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 10",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet11",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet11",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00293,
+            0.00196,
+            0.00199999986,
+            0.00182,
+            0.00165,
+            0.00151,
+            0.00109,
+            0.000830000034,
+            0.00064,
+            0.00057,
+            0.000400000019,
+            0.000299999985,
+            0.00029,
+            0.00016,
+            0.00011
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 10|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 11",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet12",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet12",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00506,
+            0.00442999974,
+            0.00375999976,
+            0.00284,
+            0.00292,
+            0.00234,
+            0.00199,
+            0.00159,
+            0.00122,
+            0.00101,
+            0.000830000034,
+            0.00072,
+            0.00054,
+            0.00031,
+            0.00024,
+            0.00016
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 11|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 12",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet13",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet13",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00441,
+            0.00337,
+            0.00286000012,
+            0.00217,
+            0.00192999991,
+            0.00183000008,
+            0.00148,
+            0.00128,
+            0.00099,
+            0.00079,
+            0.00061,
+            0.00055,
+            0.000450000021,
+            0.00033,
+            0.000149999993,
+            8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 12|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 13",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet14",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet14",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00502,
+            0.00407,
+            0.00297,
+            0.00257,
+            0.00242,
+            0.00214,
+            0.00168,
+            0.00124,
+            0.000860000029,
+            0.00068,
+            0.00056,
+            0.00046,
+            0.00044,
+            0.000249999983,
+            0.00017,
+            0.00012
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 13|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.87,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 14",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet15",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet15",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0053,
+            0.00355,
+            0.00363000017,
+            0.00296,
+            0.003,
+            0.00253,
+            0.00214,
+            0.00182,
+            0.00147,
+            0.00118,
+            0.0011,
+            0.000949999958,
+            0.00082,
+            0.00041,
+            0.00026,
+            0.00016
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 14|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.72,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 15",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet16",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet16",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00556,
+            0.00463,
+            0.00375,
+            0.0035,
+            0.00371,
+            0.00336,
+            0.00262,
+            0.0023,
+            0.00167,
+            0.00127,
+            0.00114,
+            0.000949999958,
+            0.00067,
+            0.000299999985,
+            0.00017
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 15|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.72,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 16",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet17",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet17",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00625,
+            0.00451,
+            0.00381,
+            0.00285,
+            0.00273,
+            0.00227,
+            0.00164,
+            0.00122999994,
+            0.000860000029,
+            0.00068,
+            0.00057,
+            0.00051,
+            0.000430000015,
+            0.00029,
+            0.00022,
+            0.00016,
+            0.000100000005
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 16|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 17",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\katharina.wieser\\Documents\\PBPK Model Levonorgestrel\\LNG Model with A229\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.Sheet18",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet18",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "0.09 mg",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE",
+          "RelatedColumns": [
+            {
+              "Name": "LLOQ",
+              "QuantityInfo": {
+                "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|LLOQ"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN",
+                "NaN"
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel|PK_VALUE"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00338000013,
+            0.00242,
+            0.00224,
+            0.00235,
+            0.00196,
+            0.00189999992,
+            0.00152,
+            0.00115,
+            0.00081,
+            0.00066,
+            0.00059,
+            0.000430000015,
+            0.00036,
+            0.00021,
+            0.00013,
+            8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 17|TAD_VALUE",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "mean_SD_LNG_IV_0_09 mg",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "D:\\Gates\\Levonorgestrel\\mean_SD_LNG_IV_0_09 mg.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "mean_SD_LNG_IV_0_09 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "mean (ng/L)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "mean_SD_LNG_IV_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                1392.76282,
+                1173.56274,
+                925.782532,
+                734.1165,
+                736.293457,
+                617.860535,
+                501.298,
+                428.4739,
+                348.010681,
+                299.105957,
+                269.009918,
+                228.52182,
+                194.724548,
+                91.73572,
+                64.46899,
+                50.6496277,
+                19.235384
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/l"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "mean_SD_LNG_IV_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|mean (ng/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00462333346,
+            0.0035555556,
+            0.00322555564,
+            0.00269277766,
+            0.002538889,
+            0.002228889,
+            0.00175944448,
+            0.00140611117,
+            0.0010505555,
+            0.0008194445,
+            0.0006338889,
+            0.0005188889,
+            0.00046,
+            0.0002782353,
+            0.000193125,
+            0.000145,
+            9.8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "time (h)",
+        "QuantityInfo": {
+          "Path": "mean_SD_LNG_IV_0_09 mg|time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "mean_SD_LNG_PO_0_09 mg",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "D:\\Gates\\Levonorgestrel\\mean_SD_LNG_PO_0_09 mg.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "mean_SD_LNG_PO_0_09 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ng/L)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "mean_SD_LNG_PO_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                934.3477,
+                985.2634,
+                945.3742,
+                718.914368,
+                558.8644,
+                397.569824,
+                302.518829,
+                233.892883,
+                195.207275,
+                174.195633,
+                96.22673,
+                76.20149,
+                39.5658264,
+                15.2752514
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/l"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "mean_SD_LNG_PO_0_09 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00129944447,
+            0.00204166654,
+            0.00221833331,
+            0.00191555545,
+            0.0016033334,
+            0.00110833335,
+            0.0007533333,
+            0.0005466667,
+            0.000453333341,
+            0.000375,
+            0.000240625,
+            0.0001775,
+            0.000126363637,
+            9.33333358E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "time (h)",
+        "QuantityInfo": {
+          "Path": "mean_SD_LNG_PO_0_09 mg|time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "mean_SD_LNG_PO_0_27 mg",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "D:\\Gates\\Levonorgestrel\\mean_SD_LNG_PO_0_27 mg.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "mean_SD_LNG_PO_0_27 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ng/L)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "mean_SD_LNG_PO_0_27 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                2387.92847,
+                2459.54834,
+                2108.44287,
+                1718.08374,
+                1377.13635,
+                945.3932,
+                793.1564,
+                603.787659,
+                520.537659,
+                527.0032,
+                291.5728,
+                196.2658,
+                129.060211,
+                45.6667747
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/l"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "mean_SD_LNG_PO_0_27 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00345833343,
+            0.005096111,
+            0.005583889,
+            0.00522,
+            0.00449111126,
+            0.00307058822,
+            0.00209166668,
+            0.00149777776,
+            0.00123777776,
+            0.00110833335,
+            0.000618333346,
+            0.000445555575,
+            0.0002872222,
+            0.000156363632
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "time (h)",
+        "QuantityInfo": {
+          "Path": "mean_SD_LNG_PO_0_27 mg|time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LLOQ_Microlut_0_36 h",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "D:\\Gates\\Levonorgestrel\\LLOQ_Microlut_0_36 h.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LLOQ_Microlut_0_36 h",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "LLOQ (ng/L)",
+          "QuantityInfo": {
+            "Path": "LLOQ_Microlut_0_36 h|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|LLOQ (ng/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.1,
+            0.1
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time",
+        "QuantityInfo": {
+          "Path": "LLOQ_Microlut_0_36 h|Time",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "D:\\Gates\\Levonorgestrel\\mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ug/L)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                0.291448176,
+                0.2669259,
+                0.429381818,
+                0.1746766,
+                0.165411636,
+                0.119270287,
+                0.103689887,
+                0.09192661,
+                0.09475066,
+                0.0697241649,
+                0.0466633253,
+                0.346245736,
+                0.3719307,
+                0.331004471,
+                0.278654933,
+                0.238832816,
+                0.184134021,
+                0.1675234,
+                0.1507604,
+                0.166608632,
+                0.134240732,
+                0.09672191
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "µg/l"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.6496619,
+            0.8490381,
+            0.9100762,
+            0.6878476,
+            0.5752524,
+            0.38391903,
+            0.295066655,
+            0.229523808,
+            0.2039238,
+            0.166766673,
+            0.1243579,
+            0.77388,
+            0.928315,
+            0.943049967,
+            0.852285,
+            0.719375,
+            0.546905041,
+            0.455735,
+            0.3865,
+            0.340725,
+            0.288815,
+            0.20378001
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "time (h)",
+        "QuantityInfo": {
+          "Path": "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28|time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          672.5,
+          672.75,
+          673.0,
+          673.5,
+          674.0,
+          675.0,
+          676.0,
+          678.0,
+          680.0,
+          684.0,
+          696.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "mean_SD_LNG_PO_0_03 mg",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "E:\\Gates\\Levonorgestrel\\mean_SD_LNG_PO_0_03 mg.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "mean_SD_LNG_PO_0_03 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ug/L)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "mean_SD_LNG_PO_0_03 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                357.255676,
+                322.968262,
+                236.922668,
+                192.299469,
+                167.515488,
+                114.724739,
+                83.8064957,
+                47.7293968,
+                64.11271,
+                21.08784,
+                15.811389
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/l"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "mean_SD_LNG_PO_0_03 mg|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.000532352948,
+            0.0006955555,
+            0.000715000031,
+            0.000605555542,
+            0.000514444429,
+            0.0003435294,
+            0.000233333325,
+            0.000179333336,
+            0.000167857143,
+            0.000145833328,
+            9.666667E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "time (h)",
+        "QuantityInfo": {
+          "Path": "mean_SD_LNG_PO_0_03 mg|time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "mean_SD_LNG_PO_0_03mg_SS_DAY_01",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "E:\\Gates\\Levonorgestrel\\mean_SD_LNG_PO_0_03mg_SS_DAY_01.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "mean_SD_LNG_PO_0_03mg_SS_DAY_01",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ug/L)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "mean_SD_LNG_PO_0_03mg_SS_DAY_01|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                0.291448176,
+                0.2669259,
+                0.429381818,
+                0.1746766,
+                0.165411636,
+                0.119270287,
+                0.103689887,
+                0.09192661,
+                0.09475066,
+                0.0697241649,
+                0.0466633253
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "µg/l"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "mean_SD_LNG_PO_0_03mg_SS_DAY_01|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ug/L)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0006496619,
+            0.00084903813,
+            0.0009100762,
+            0.0006878476,
+            0.0005752524,
+            0.000383919047,
+            0.000295066653,
+            0.000229523808,
+            0.0002039238,
+            0.000166766666,
+            0.0001243579
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "time (h)",
+        "QuantityInfo": {
+          "Path": "mean_SD_LNG_PO_0_03mg_SS_DAY_01|time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "natavio2019_normal BMI digitized",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "E:\\Gates\\Levonorgestrel\\natavio2019_normal BMI digitized.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "natavio2019_normal BMI digitized",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ng/mL)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "natavio2019_normal BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                3.5,
+                3.5,
+                2.7,
+                2.5667,
+                2.6667,
+                1.76667,
+                1.93332994,
+                1.63333,
+                1.33334,
+                1.36667,
+                0.66667,
+                0.7
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/ml"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "natavio2019_normal BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            11.1333,
+            14.7667,
+            14.3667,
+            12.2332993,
+            9.2,
+            7.13333,
+            6.06667,
+            5.2,
+            4.53333,
+            2.33333,
+            1.23333,
+            0.6
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/ml"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time (h)",
+        "QuantityInfo": {
+          "Path": "natavio2019_normal BMI digitized|Time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          16.0,
+          24.0,
+          48.0,
+          72.0,
+          96.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "natavio2019_Class I and II BMI digitized",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "E:\\Gates\\Levonorgestrel\\natavio2019_Class I and II BMI digitized.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "natavio2019_Class I and II BMI digitized",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ng/mL)",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "natavio2019_Class I and II BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                4.00003,
+                3.23333,
+                1.83333,
+                1.66667,
+                1.36667,
+                1.3,
+                1.26667,
+                1.1,
+                1.03333,
+                0.73334,
+                0.26667,
+                0.366667
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/ml"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "natavio2019_Class I and II BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            8.06667,
+            9.56667,
+            7.89999962,
+            5.7,
+            3.93333,
+            3.26667,
+            2.53333,
+            2.23333,
+            2.16666985,
+            1.23333,
+            0.900000036,
+            0.6
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/ml"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time (h)",
+        "QuantityInfo": {
+          "Path": "natavio2019_Class I and II BMI digitized|Time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          16.0,
+          24.0,
+          48.0,
+          72.0,
+          96.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "praditpan2017_normal BMI digitized",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "E:\\Gates\\Levonorgestrel\\praditpan2017_normal BMI digitized.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "praditpan2017_normal BMI digitized",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ng/mL)",
+          "QuantityInfo": {
+            "Path": "praditpan2017_normal BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            6.96714,
+            12.2334,
+            14.6657,
+            14.9931993,
+            13.7111,
+            10.648,
+            9.04243,
+            8.3268795,
+            7.53059053,
+            6.40705,
+            5.0,
+            2.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/ml"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time (h)",
+        "QuantityInfo": {
+          "Path": "praditpan2017_normal BMI digitized|Time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          24.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "praditpan2017_Class I and II BMI digitized",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "E:\\Gates\\Levonorgestrel\\praditpan2017_Class I and II BMI digitized.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "praditpan2017_Class I and II BMI digitized",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc (ng/mL)",
+          "QuantityInfo": {
+            "Path": "praditpan2017_Class I and II BMI digitized|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc (ng/mL)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            1.05599,
+            3.73117971,
+            6.56855,
+            8.51522,
+            9.17015,
+            7.15235,
+            4.65587,
+            4.10271025,
+            3.7115,
+            3.48201013,
+            2.9,
+            1.5
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/ml"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time (h)",
+        "QuantityInfo": {
+          "Path": "praditpan2017_Class I and II BMI digitized|Time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          24.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "edelman2016_unbound LNG",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\rcristofoletti\\Desktop\\Gates\\edelman2016_unbound LNG.xlsx.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "edelman2016_unbound LNG",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Conc",
+          "RelatedColumns": [
+            {
+              "Name": "SD",
+              "QuantityInfo": {
+                "Path": "edelman2016_unbound LNG|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|SD"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "MolWeight": 312.44
+              },
+              "Values": [
+                0.0,
+                0.02059905,
+                0.047,
+                0.0341842,
+                0.0271559,
+                0.0173278
+              ],
+              "Dimension": "Concentration (mass)",
+              "Unit": "ng/ml"
+            }
+          ],
+          "QuantityInfo": {
+            "Path": "edelman2016_unbound LNG|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Conc"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.0295888,
+            0.0479448,
+            0.0489762,
+            0.0476632,
+            0.0472915024
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/ml"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time (h)",
+        "QuantityInfo": {
+          "Path": "edelman2016_unbound LNG|Time (h)",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          1.0,
+          1.5,
+          2.0,
+          2.5
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 1.xlsx.LNG 0_03 mg_SS_1st day 1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column3 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column3 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.4053,
+            0.514,
+            0.4833,
+            0.359599978,
+            0.284400016,
+            0.18,
+            0.140399992,
+            0.0835,
+            0.082100004,
+            0.0677
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 1|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 2",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 2.xlsx.LNG 0_03 mg_SS_1st day 2",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 2",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 2",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column4 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column4 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.9074,
+            1.1137,
+            0.9592,
+            0.6696,
+            0.5366,
+            0.353,
+            0.3319,
+            0.2026,
+            0.169399992,
+            0.1161,
+            0.1018
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 2|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 3",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 3.xlsx.LNG 0_03 mg_SS_1st day 3",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 3",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 3",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column5 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column5 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.2701,
+            0.5323,
+            0.662900031,
+            0.8004,
+            0.6186,
+            0.4064,
+            0.2641,
+            0.1723,
+            0.1375,
+            0.1063,
+            0.0923
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 3|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 4",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 4.xlsx.LNG 0_03 mg_SS_1st day 4",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 4",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 4",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column6 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column6 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.9098,
+            1.1718,
+            1.1157,
+            0.9366,
+            0.891800046,
+            0.5924,
+            0.496700019,
+            0.3439,
+            0.3169,
+            0.2193,
+            0.1202
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 4|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 5",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 5.xlsx.LNG 0_03 mg_SS_1st day 5",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 5",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 5",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column7 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column7 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.9965,
+            1.2359,
+            0.9118,
+            0.7212,
+            0.5561,
+            0.4176,
+            0.3436,
+            0.391100019,
+            0.2674,
+            0.1812
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 5|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 6",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 6.xlsx.LNG 0_03 mg_SS_1st day 6",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 6",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 6",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column8 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column8 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.4374,
+            0.7638,
+            0.7638,
+            0.5277,
+            0.4762,
+            0.3006,
+            0.1851,
+            0.1757,
+            0.1146,
+            0.111700006,
+            0.0694
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 6|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 7",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 7.xlsx.LNG 0_03 mg_SS_1st day 7",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 7",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 7",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column9 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column9 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.1418,
+            0.313299984,
+            0.4638,
+            0.4995,
+            0.56,
+            0.3658,
+            0.3049,
+            0.2243,
+            0.1895,
+            0.1691,
+            0.1104
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 7|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 8",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 8.xlsx.LNG 0_03 mg_SS_1st day 8",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 8",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 8",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column10 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column10 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.7029,
+            0.7609,
+            0.9511,
+            0.744500041,
+            0.649700046,
+            0.497600019,
+            0.377800018,
+            0.3335,
+            0.2836,
+            0.2054,
+            0.1636
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 8|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 9",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 9.xlsx.LNG 0_03 mg_SS_1st day 9",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 9",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 9",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column11 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column11 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1.038,
+            1.2349,
+            1.1235,
+            0.843799949,
+            0.6421,
+            0.4551,
+            0.428599983,
+            0.3272,
+            0.3399,
+            0.2525,
+            0.2185
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 9|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 10",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 10.xlsx.LNG 0_03 mg_SS_1st day 10",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 10",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 10",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column12 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column12 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1.0339,
+            1.2294,
+            1.0491,
+            0.859699965,
+            0.71389997,
+            0.496900022,
+            0.4231,
+            0.382,
+            0.307199985,
+            0.252800018,
+            0.1577
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 10|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 11",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 11.xlsx.LNG 0_03 mg_SS_1st day 11",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 11",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 11",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column13 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column13 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.7921,
+            1.0285,
+            1.1385,
+            1.00599992,
+            0.888600051,
+            0.5001,
+            0.3566,
+            0.2768,
+            0.2712,
+            0.2272,
+            0.1464
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 11|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 12",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 12.xlsx.LNG 0_03 mg_SS_1st day 12",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 12",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 12",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column14 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column14 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.3157,
+            0.6071,
+            0.6967,
+            0.5436,
+            0.4034,
+            0.2392,
+            0.177600011,
+            0.129000008,
+            0.0898999944,
+            0.0729
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 12|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 13",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 13.xlsx.LNG 0_03 mg_SS_1st day 13",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 13",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 13",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column15 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column15 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.302000016,
+            0.6438,
+            0.7655,
+            0.8532,
+            0.808,
+            0.569200039,
+            0.4483,
+            0.4,
+            0.35680002,
+            0.3233,
+            0.2204
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 13|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 14",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 14.xlsx.LNG 0_03 mg_SS_1st day 14",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 14",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 14",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column16 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column16 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.48999998,
+            0.6355,
+            0.6135,
+            0.5058,
+            0.4407,
+            0.3036,
+            0.2119,
+            0.1456,
+            0.1278,
+            0.112100005,
+            0.0745
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 14|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 15",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 15.xlsx.LNG 0_03 mg_SS_1st day 15",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 15",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 15",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column17 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column17 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.3062,
+            0.66110003,
+            0.692599952,
+            0.5849,
+            0.458599985,
+            0.2809,
+            0.248900011,
+            0.1946,
+            0.179899991,
+            0.156199992,
+            0.105000004
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 15|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 16",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 16.xlsx.LNG 0_03 mg_SS_1st day 16",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 16",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 16",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column18 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column18 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.9451,
+            0.99849993,
+            0.945,
+            0.7382,
+            0.5252,
+            0.346000016,
+            0.2669,
+            0.194200009,
+            0.162399992,
+            0.154,
+            0.0894999951
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 16|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 17",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 17.xlsx.LNG 0_03 mg_SS_1st day 17",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 17",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 17",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column19 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column19 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.7454,
+            0.9437,
+            0.7904,
+            0.569099963,
+            0.404400021,
+            0.286,
+            0.195100009,
+            0.1514,
+            0.131599993,
+            0.1023,
+            0.0835
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 17|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 18",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 18.xlsx.LNG 0_03 mg_SS_1st day 18",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 18",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 18",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column20 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 18|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column20 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.7766,
+            0.9684,
+            0.8804,
+            0.6387,
+            0.474600017,
+            0.3607,
+            0.242499992,
+            0.20099999,
+            0.179899991,
+            0.165,
+            0.101900004
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 18|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 20",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 20.xlsx.LNG 0_03 mg_SS_1st day 20",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 20",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 20",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column22 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 20|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column22 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.4752,
+            0.6789,
+            0.746300042,
+            0.48999998,
+            0.3951,
+            0.263,
+            0.202100009,
+            0.1512,
+            0.126,
+            0.1071,
+            0.0813
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 20|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day 19",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day 19.xlsx.LNG 0_03 mg_SS_1st day 19",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day 19",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day 19",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column21 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day 19|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column21 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.693,
+            0.8996,
+            0.8621,
+            0.743800044,
+            0.664000034,
+            0.44599998,
+            0.2614,
+            0.24149999,
+            0.2033,
+            0.1778,
+            0.0921
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day 19|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_03 mg_SS_1st day",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.03mg_Data\\LNG 0_03 mg_SS_1st day.xlsx.LNG 0_03 mg_SS_1st day",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_03 mg_SS_1st day",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_03 mg_SS_1st day",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column2 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_03 mg_SS_1st day|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column2 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            0.958499968,
+            0.8947,
+            0.8232,
+            0.6183,
+            0.5232,
+            0.2637,
+            0.2149,
+            0.1461,
+            0.1218,
+            0.1359,
+            0.1531
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "µg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_03 mg_SS_1st day|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 1.xlsx.LNG 0_09 mg_single dose 1",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column3 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column3 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            2340.0,
+            2560.0,
+            2520.0,
+            1780.0,
+            1490.0,
+            1070.0,
+            760.0,
+            540.0,
+            450.0,
+            340.0,
+            210.0,
+            170.0,
+            110.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 1|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 2.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 2",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00596,
+            0.00423,
+            0.00471,
+            0.00411999971,
+            0.00359,
+            0.00298,
+            0.00228,
+            0.00183000008,
+            0.0014,
+            0.00127,
+            0.00096,
+            0.00064,
+            0.00061,
+            0.00036,
+            0.00023,
+            0.000200000009
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 3.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 3",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00419,
+            0.00345,
+            0.00343,
+            0.00289000012,
+            0.00276,
+            0.00266,
+            0.00177000009,
+            0.00158,
+            0.00143000006,
+            0.00105,
+            0.00079,
+            0.00061,
+            0.00055,
+            0.00038,
+            0.000249999983,
+            0.000249999983,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 2",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 2.xlsx.LNG 0_09 mg_single dose 2",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 2",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 2",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column4 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column4 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            2880.0,
+            3270.0,
+            2910.0,
+            2660.0,
+            2090.0,
+            1530.0,
+            900.0,
+            690.0,
+            550.0,
+            469.999969,
+            340.0,
+            190.0,
+            119.999992
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 2|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 6.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 6",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00317000016,
+            0.00266,
+            0.00208,
+            0.00226,
+            0.00199,
+            0.00176,
+            0.00143000006,
+            0.00126,
+            0.00082,
+            0.00063,
+            0.00041,
+            0.000299999985,
+            0.00024,
+            0.00014,
+            9E-05,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 5.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 5",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00421,
+            0.00315,
+            0.00278,
+            0.00227,
+            0.00198,
+            0.00162,
+            0.00146,
+            0.00098,
+            0.00069,
+            0.000499999966,
+            0.00031,
+            0.00027,
+            0.00027,
+            0.00019,
+            9E-05,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 7.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 7",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00604,
+            0.00401,
+            0.00414,
+            0.00313,
+            0.00265,
+            0.00233,
+            0.00186000008,
+            0.00134,
+            0.00113,
+            0.00088,
+            0.00062,
+            0.000529999961,
+            0.000499999966,
+            0.00029,
+            0.00023,
+            0.00016,
+            8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 8.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 8",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00625,
+            0.00476,
+            0.00368,
+            0.00319,
+            0.00307,
+            0.00275,
+            0.00239999988,
+            0.00173,
+            0.00133,
+            0.00093999994,
+            0.00061,
+            0.00056,
+            0.00057,
+            0.000299999985,
+            0.000200000009,
+            0.00012
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 9.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 9",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0069,
+            0.006,
+            0.00459,
+            0.00355,
+            0.00349,
+            0.0031,
+            0.0025,
+            0.00204,
+            0.00127,
+            0.00096,
+            0.00071,
+            0.00065,
+            0.00068,
+            0.00035,
+            0.00029,
+            0.00019,
+            0.00013
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 10.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 10",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00293,
+            0.00196,
+            0.00199999986,
+            0.00182,
+            0.00165,
+            0.00151,
+            0.00109,
+            0.000830000034,
+            0.00064,
+            0.00057,
+            0.000400000019,
+            0.000299999985,
+            0.00029,
+            0.00016,
+            0.00011
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 11.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 11",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00506,
+            0.00442999974,
+            0.00375999976,
+            0.00284,
+            0.00292,
+            0.00234,
+            0.00199,
+            0.00159,
+            0.00122,
+            0.00101,
+            0.000830000034,
+            0.00072,
+            0.00054,
+            0.00031,
+            0.00024,
+            0.00016
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 12.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 12",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00441,
+            0.00337,
+            0.00286000012,
+            0.00217,
+            0.00192999991,
+            0.00183000008,
+            0.00148,
+            0.00128,
+            0.00099,
+            0.00079,
+            0.00061,
+            0.00055,
+            0.000450000021,
+            0.00033,
+            0.000149999993,
+            8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 13.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 13",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00502,
+            0.00407,
+            0.00297,
+            0.00257,
+            0.00242,
+            0.00214,
+            0.00168,
+            0.00124,
+            0.000860000029,
+            0.00068,
+            0.00056,
+            0.00046,
+            0.00044,
+            0.000249999983,
+            0.00017,
+            0.00012
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.87,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 14.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 14",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0053,
+            0.00355,
+            0.00363000017,
+            0.00296,
+            0.003,
+            0.00253,
+            0.00214,
+            0.00182,
+            0.00147,
+            0.00118,
+            0.0011,
+            0.000949999958,
+            0.00082,
+            0.00041,
+            0.00026,
+            0.00016
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.72,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 16.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 16",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00625,
+            0.00451,
+            0.00381,
+            0.00285,
+            0.00273,
+            0.00227,
+            0.00164,
+            0.00122999994,
+            0.000860000029,
+            0.00068,
+            0.00057,
+            0.00051,
+            0.000430000015,
+            0.00029,
+            0.00022,
+            0.00016,
+            0.000100000005
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution 17.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution 17",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00338000013,
+            0.00242,
+            0.00224,
+            0.00235,
+            0.00196,
+            0.00189999992,
+            0.00152,
+            0.00115,
+            0.00081,
+            0.00066,
+            0.00059,
+            0.000430000015,
+            0.00036,
+            0.00021,
+            0.00013,
+            8E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.09mg_solution 18",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\IV\\ocp_dataset_V2_KW_A229_0.09mg_solution.xlsx.ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg_solution",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.09mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 18|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.00353,
+            0.00353,
+            0.00387,
+            0.00320000015,
+            0.00308,
+            0.0025,
+            0.00187999988,
+            0.00149,
+            0.00126,
+            0.00107,
+            0.00076,
+            0.00059,
+            0.00061,
+            0.00037,
+            0.00026,
+            0.00017,
+            9E-05
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.09mg_solution 18|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0800000057,
+          0.17,
+          0.25,
+          0.53,
+          0.75,
+          1.0,
+          1.63,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 3",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 3.xlsx.LNG 0_09 mg_single dose 3",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 3",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 3",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column5 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column5 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            690.0,
+            1480.0,
+            1420.0,
+            1040.0,
+            880.0,
+            530.0,
+            320.0,
+            220.0,
+            170.0,
+            150.0,
+            110.0,
+            80.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 3|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 5",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 5.xlsx.LNG 0_09 mg_single dose 5",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 5",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 5",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column7 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column7 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1380.0,
+            2550.0,
+            2540.0,
+            2020.0,
+            1590.0,
+            939.999939,
+            560.0,
+            479.999969,
+            430.0,
+            420.0,
+            239.999985,
+            160.0,
+            100.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 5|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 4",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 4.xlsx.LNG 0_09 mg_single dose 4",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 4",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 4",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column6 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column6 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            2040.0,
+            2720.0,
+            3000.0,
+            2370.0,
+            1830.0,
+            1410.0,
+            1010.0,
+            720.0,
+            620.0,
+            430.0,
+            200.0,
+            130.0,
+            90.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 4|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 6",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 6.xlsx.LNG 0_09 mg_single dose 6",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 6",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 6",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column8 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column8 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            2210.0,
+            2500.0,
+            2610.0,
+            2130.0,
+            1500.0,
+            1100.0,
+            770.0,
+            550.0,
+            469.999969,
+            410.0,
+            220.0,
+            150.0,
+            80.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 6|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 7",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 7.xlsx.LNG 0_09 mg_single dose 7",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 7",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 7",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column9 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column9 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            80.0,
+            260.0,
+            580.0,
+            880.0,
+            890.0,
+            540.0,
+            260.0,
+            220.0,
+            160.0,
+            119.999992
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 7|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 8",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 8.xlsx.LNG 0_09 mg_single dose 8",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 8",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 8",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column10 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column10 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            270.0,
+            850.0,
+            1590.0,
+            1909.99988,
+            1620.0,
+            1060.0,
+            770.0,
+            530.0,
+            420.0,
+            320.0,
+            160.0,
+            110.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 8|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 9",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 9.xlsx.LNG 0_09 mg_single dose 9",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 9",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 9",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column11 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column11 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            3160.0,
+            3700.0,
+            3900.0,
+            3000.0,
+            2230.0,
+            1430.0,
+            1050.0,
+            830.0,
+            680.0,
+            610.0,
+            350.0,
+            350.0,
+            220.0,
+            110.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 9|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 10",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 10.xlsx.LNG 0_09 mg_single dose 10",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 10",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 10",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column12 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column12 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            260.0,
+            700.0,
+            959.999939,
+            1080.0,
+            1170.0,
+            830.0,
+            510.0,
+            260.0,
+            190.0,
+            130.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 10|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 11",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 11.xlsx.LNG 0_09 mg_single dose 11",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 11",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 11",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column13 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column13 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            640.0,
+            2800.0,
+            3000.0,
+            2970.0,
+            2680.0,
+            1879.99988,
+            1250.0,
+            790.0,
+            650.0,
+            600.0,
+            340.0,
+            290.0,
+            160.0,
+            90.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 11|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 12",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 12.xlsx.LNG 0_09 mg_single dose 12",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 12",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 12",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column14 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column14 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1370.0,
+            1710.0,
+            1850.0,
+            1420.0,
+            1170.0,
+            750.0,
+            490.0,
+            340.0,
+            310.0,
+            270.0,
+            190.0,
+            180.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 12|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 13",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 13.xlsx.LNG 0_09 mg_single dose 13",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 13",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 13",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column15 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column15 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1510.0,
+            2160.0,
+            2700.0,
+            2000.0,
+            1840.0,
+            1290.0,
+            959.999939,
+            660.0,
+            500.0,
+            400.0,
+            210.0,
+            160.0,
+            100.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 13|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 15",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 15.xlsx.LNG 0_09 mg_single dose 15",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 15",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 15",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column17 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column17 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1280.0,
+            2020.0,
+            1980.0,
+            1820.0,
+            1490.0,
+            1130.0,
+            1050.0,
+            910.0,
+            660.0,
+            600.0,
+            410.0,
+            239.999985,
+            130.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 15|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 14",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 14.xlsx.LNG 0_09 mg_single dose 14",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 14",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 14",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column16 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column16 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            190.0,
+            680.0,
+            1110.0,
+            1240.0,
+            1100.0,
+            830.0,
+            460.0,
+            290.0,
+            250.0,
+            200.0,
+            110.0,
+            80.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 14|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 16",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 16.xlsx.LNG 0_09 mg_single dose 16",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 16",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 16",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column18 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column18 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            939.999939,
+            2910.0,
+            3530.0,
+            2800.0,
+            2340.0,
+            1610.0,
+            1030.0,
+            700.0,
+            660.0,
+            500.0,
+            330.0,
+            220.0,
+            130.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 16|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose 17",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose 17.xlsx.LNG 0_09 mg_single dose 17",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose 17",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose 17",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column19 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose 17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column19 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            1560.0,
+            2650.0,
+            2700.0,
+            2550.0,
+            2230.0,
+            1480.0,
+            1050.0,
+            840.0,
+            750.0,
+            620.0,
+            320.0,
+            239.999985,
+            150.0,
+            80.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose 17|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "LNG 0_09 mg_single dose",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG0.09mg_Data\\LNG 0_09 mg_single dose.xlsx.LNG 0_09 mg_single dose",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "LNG 0_09 mg_single dose",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "LNG 0_09 mg_single dose",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Column2 ",
+          "QuantityInfo": {
+            "Path": "LNG 0_09 mg_single dose|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|Column2 "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            0.0,
+            590.0,
+            1230.0,
+            1030.0,
+            810.0,
+            720.0,
+            540.0,
+            360.0,
+            270.0,
+            239.999985,
+            160.0,
+            110.0,
+            90.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Column1 ",
+        "QuantityInfo": {
+          "Path": "LNG 0_09 mg_single dose|Column1 ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.0,
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet1.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet1",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet1|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            7230.0,
+            10400.0,
+            8530.0,
+            7350.0,
+            4960.0,
+            3450.0,
+            2470.0,
+            1820.0,
+            1510.0,
+            1250.0,
+            870.0,
+            640.0,
+            400.0,
+            190.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet1|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet2",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet2.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet2",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet2|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            1040.0,
+            2410.0,
+            3270.0,
+            2770.0,
+            2450.0,
+            1790.0,
+            1030.0,
+            760.0,
+            500.0,
+            380.0,
+            210.0,
+            150.0,
+            90.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet2|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet3",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet3.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet3",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet3|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            6080.0,
+            8060.0,
+            7450.0,
+            7830.0,
+            6650.0,
+            4670.0,
+            3200.0,
+            2120.0,
+            1810.0,
+            2160.0,
+            1280.0,
+            750.0,
+            500.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet3|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet4",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet4.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet4",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet4|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            2720.0,
+            5500.0,
+            6730.0,
+            5470.0,
+            4630.0,
+            3779.99976,
+            2340.0,
+            1690.0,
+            1440.0,
+            1400.0,
+            740.0,
+            530.0,
+            400.0,
+            150.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet4|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet5",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet5.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet5",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet5|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            270.0,
+            820.0,
+            1160.0,
+            1740.0,
+            2010.0,
+            2210.0,
+            1200.0,
+            540.0,
+            430.0,
+            260.0,
+            200.0,
+            130.0,
+            100.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet5|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet7",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet7.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet7",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet7|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            1300.0,
+            2680.0,
+            3470.0,
+            3450.0,
+            3130.0,
+            1960.0,
+            1250.0,
+            949.999939,
+            690.0,
+            530.0,
+            380.0,
+            239.999985,
+            160.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet7|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet6",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet6.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet6",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet6|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            530.0,
+            2420.0,
+            3220.0,
+            4320.0,
+            3960.0,
+            2310.0,
+            1510.0,
+            1020.0,
+            710.0,
+            520.0,
+            320.0,
+            270.0,
+            190.0,
+            100.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet6|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet8",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet8.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet8",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet8|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            7320.0,
+            7390.0,
+            7749.99951,
+            7240.0,
+            6900.0,
+            4650.0,
+            3809.99976,
+            2440.0,
+            1919.99988,
+            1840.0,
+            800.0,
+            640.0,
+            440.0,
+            200.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet8|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet9",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet9.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet9",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet9|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            4590.0,
+            6370.0,
+            7749.99951,
+            6030.0,
+            4610.0,
+            2830.0,
+            1730.0,
+            1310.0,
+            1240.0,
+            1110.0,
+            390.0,
+            570.0,
+            239.999985,
+            100.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet9|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet10",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet10.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet10",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet10|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            4720.0,
+            6760.0,
+            7190.0,
+            6700.0,
+            5850.0,
+            2030.0,
+            1540.0,
+            1380.0,
+            1290.0,
+            690.0,
+            640.0,
+            400.0,
+            190.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet10|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet11",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet11.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet11",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet11|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            2580.0,
+            3350.0,
+            3700.0,
+            3080.0,
+            2500.0,
+            1680.0,
+            1140.0,
+            750.0,
+            660.0,
+            590.0,
+            320.0,
+            220.0,
+            140.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet11|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet12",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet12.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet12",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet12|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            3879.99976,
+            6000.0,
+            6820.0,
+            5780.0,
+            5400.0,
+            3530.0,
+            2540.0,
+            2020.0,
+            1730.0,
+            1400.0,
+            820.0,
+            450.0,
+            300.0,
+            150.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet12|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet13",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet13.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet13",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet13|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            6170.0,
+            6910.0,
+            6060.0,
+            5360.0,
+            4880.0,
+            3420.0,
+            2400.0,
+            1500.0,
+            1470.0,
+            1280.0,
+            1000.0,
+            580.0,
+            370.0,
+            150.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet13|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet14",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet14.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet14",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet14|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            4760.0,
+            6600.0,
+            7579.99951,
+            6200.0,
+            4500.0,
+            3200.0,
+            2080.0,
+            1570.0,
+            1090.0,
+            1600.0,
+            710.0,
+            420.0,
+            290.0,
+            150.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet14|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet15",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet15.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet15",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet15|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            1430.0,
+            3390.0,
+            4610.0,
+            5990.0,
+            5170.0,
+            3940.0,
+            3060.0,
+            2290.0,
+            1909.99988,
+            1330.0,
+            760.0,
+            460.0,
+            330.0,
+            100.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet15|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet16",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet16.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet16",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet16|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            5250.0,
+            5590.0,
+            6590.0,
+            6030.0,
+            5280.0,
+            3660.0,
+            2740.0,
+            2470.0,
+            1990.0,
+            1440.0,
+            620.0,
+            370.0,
+            220.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet16|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet17",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet17.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet17",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet17|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            620.0,
+            3849.99976,
+            4900.0,
+            5020.0,
+            4560.0,
+            3030.0,
+            1760.0,
+            1130.0,
+            949.999939,
+            880.0,
+            620.0,
+            690.0,
+            440.0,
+            239.999985
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet17|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0,
+          72.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "ocp_dataset_V2_KW_A229_0.27mg.Sheet18",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "C:\\Users\\Brian\\OneDrive - University of Florida\\Summer2020\\PHA7979_Advanced Research\\HCA\\Victims\\LNG\\LNG.27mg_Data\\ocp_dataset_V2_KW_A229_0.27mg.Sheet18.xlsx.ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg.Sheet18",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "ocp_dataset_V2_KW_A229_0.27mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Levonorgestrel 1",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "PK_VALUE ",
+          "QuantityInfo": {
+            "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet18|ObservedData|Peripheral Venous Blood|Plasma|Levonorgestrel 1|PK_VALUE "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 312.44
+          },
+          "Values": [
+            1760.0,
+            3230.0,
+            3729.99976,
+            3600.0,
+            3400.0,
+            2090.0,
+            1360.0,
+            1040.0,
+            850.0,
+            690.0,
+            400.0,
+            270.0,
+            160.0
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "ng/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "TAD_VALUE ",
+        "QuantityInfo": {
+          "Path": "ocp_dataset_V2_KW_A229_0.27mg.Sheet18|TAD_VALUE ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.5,
+          0.75,
+          1.0,
+          1.5,
+          2.0,
+          3.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          24.0,
+          36.0,
+          48.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    }
+  ],
+  "ObservedDataClassifications": [
+    {
+      "Name": "IV_LNG_0.09 mg mixed micelle solution",
+      "Classifiables": [
+        "ocp_dataset_V2_KW_A229_0.09mg_solution",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 1",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 2",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 3",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 4",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 5",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 6",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 7",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 8",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 9",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 10",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 11",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 12",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 13",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 14",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 15",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 16",
+        "ocp_dataset_V2_KW_A229_0.09mg_solution 17"
+      ]
+    },
+    {
+      "Name": "Microlut (progestin only)",
+      "Classifications": [
+        {
+          "Name": "Raw_Data",
+          "Classifications": [
+            {
+              "Name": "0.03_PO",
+              "Classifiables": [
+                "LNG 0_03 mg_SS_1st day 1",
+                "LNG 0_03 mg_SS_1st day 2",
+                "LNG 0_03 mg_SS_1st day 3",
+                "LNG 0_03 mg_SS_1st day 4",
+                "LNG 0_03 mg_SS_1st day 5",
+                "LNG 0_03 mg_SS_1st day 6",
+                "LNG 0_03 mg_SS_1st day 7",
+                "LNG 0_03 mg_SS_1st day 8",
+                "LNG 0_03 mg_SS_1st day 9",
+                "LNG 0_03 mg_SS_1st day 10",
+                "LNG 0_03 mg_SS_1st day 11",
+                "LNG 0_03 mg_SS_1st day 12",
+                "LNG 0_03 mg_SS_1st day 13",
+                "LNG 0_03 mg_SS_1st day 14",
+                "LNG 0_03 mg_SS_1st day 15",
+                "LNG 0_03 mg_SS_1st day 16",
+                "LNG 0_03 mg_SS_1st day 17",
+                "LNG 0_03 mg_SS_1st day 18",
+                "LNG 0_03 mg_SS_1st day 20",
+                "LNG 0_03 mg_SS_1st day 19",
+                "LNG 0_03 mg_SS_1st day"
+              ]
+            },
+            {
+              "Name": "0.09_PO",
+              "Classifiables": [
+                "LNG 0_09 mg_single dose 1",
+                "LNG 0_09 mg_single dose 2",
+                "LNG 0_09 mg_single dose 3",
+                "LNG 0_09 mg_single dose 5",
+                "LNG 0_09 mg_single dose 4",
+                "LNG 0_09 mg_single dose 6",
+                "LNG 0_09 mg_single dose 7",
+                "LNG 0_09 mg_single dose 8",
+                "LNG 0_09 mg_single dose 9",
+                "LNG 0_09 mg_single dose 10",
+                "LNG 0_09 mg_single dose 11",
+                "LNG 0_09 mg_single dose 12",
+                "LNG 0_09 mg_single dose 13",
+                "LNG 0_09 mg_single dose 15",
+                "LNG 0_09 mg_single dose 14",
+                "LNG 0_09 mg_single dose 16",
+                "LNG 0_09 mg_single dose 17",
+                "LNG 0_09 mg_single dose"
+              ]
+            },
+            {
+              "Name": "0.27_PO",
+              "Classifiables": [
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet1",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet2",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet3",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet4",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet5",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet7",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet6",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet8",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet9",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet10",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet11",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet12",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet13",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet14",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet15",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet16",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet17",
+                "ocp_dataset_V2_KW_A229_0.27mg.Sheet18"
+              ]
+            },
+            {
+              "Name": "0.09_IV",
+              "Classifiables": [
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 2 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 3 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 6 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 5 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 7 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 8 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 9 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 10 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 11 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 12 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 13 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 14 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 16 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 17 1",
+                "ocp_dataset_V2_KW_A229_0.09mg_solution 18"
+              ]
+            }
+          ]
+        }
+      ],
+      "Classifiables": [
+        "mean_SD_LNG_IV_0_09 mg",
+        "mean_SD_LNG_PO_0_09 mg",
+        "mean_SD_LNG_PO_0_27 mg",
+        "LLOQ_Microlut_0_36 h",
+        "mean_SD_LNG_PO_0_03mg_SS_DAYS_01_28",
+        "mean_SD_LNG_PO_0_03 mg",
+        "mean_SD_LNG_PO_0_03mg_SS_DAY_01"
+      ]
+    },
+    {
+      "Name": "Obese patients",
+      "Classifiables": [
+        "natavio2019_normal BMI digitized",
+        "natavio2019_Class I and II BMI digitized",
+        "praditpan2017_normal BMI digitized",
+        "praditpan2017_Class I and II BMI digitized"
+      ]
+    },
+    {
+      "Name": "unbound LNG_edelman et al 2016",
+      "Classifiables": [
+        "edelman2016_unbound LNG"
+      ]
+    }
+  ],
+  "SimulationClassifications": [
+    {
+      "Name": "Model development - progestin only (Microlut)",
+      "Classifiables": [
+        "IV",
+        "LNG 0.09 mg IV - Bayer Study A229",
+        "LNG 0.09 mg PO (Microlut) - Bayer Study A53768",
+        "LNG 0.09 mg IV - Bayer Study A229 fmCYP3A4"
+      ]
+    },
+    {
+      "Name": "Model verification",
+      "Classifications": [
+        {
+          "Name": "Progestin only (Microlut)",
+          "Classifiables": [
+            "LNG 0.03 mg PO single dose - Bayer Study A53768",
+            "LNG 0.03 mg PO multiple doses - Bayer Study A53768",
+            "LNG 0.27 mg PO single dose - Bayer Study A53768"
+          ]
+        },
+        {
+          "Name": "SA Progestin-only",
+          "Classifiables": [
+            "LNG 0.03 mg standard",
+            "LNG 0.03 mg 40% less",
+            "LNG 0.03 mg 40% more"
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "Special populations",
+      "Classifications": [
+        {
+          "Name": "Obese patients - Natavio et al 2019 (Contraception 99_306-311) - PK fasted",
+          "Classifiables": [
+            "Natavio et al 2019 - Class I and II BMI",
+            "Natavio et al 2019 - Normal BMI"
+          ]
+        },
+        {
+          "Name": "Obese patients - Praditpan et al 2017 (Contraception 95_464-469) - PK fed low fat",
+          "Classifiables": [
+            "Praditpan et al 2017 - Class I and II BMI",
+            "Praditpan et al 2017 - Normal BMI"
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "DDI scenarios - Control",
+      "Classifications": [
+        {
+          "Name": "Bayer Study 19604",
+          "Classifiables": [
+            "Bayer Study 19604 - control Day 1"
+          ]
+        },
+        {
+          "Name": "Carten et al 2012 (doi 10.1155/2012/137192)",
+          "Classifiables": [
+            "LNG 0.75 mg population"
+          ]
+        },
+        {
+          "Name": "Healthy",
+          "Classifiables": [
+            "DDI_LNG150ug_21days"
+          ]
+        },
+        {
+          "Name": "Obese",
+          "Classifiables": [
+            "DDI_LNG150ug_21days_Obe"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Remove all other compounds info from the pksim project in pk-sim to export snapshot with only levonorgestrel. 