### PR TITLE
Fix pivot_wider duplicate values warning in PK analysis

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -139,7 +139,8 @@ pivot_pk_analysis <- function(df, compound_names) {
     dplyr::rename(QuantityPath = UniqueQuantityPath) %>%
     tidyr::pivot_wider(
       names_from = Compound,
-      values_from = Value
+      values_from = Value,
+      values_fn = list
     ) %>%
     dplyr::relocate(QuantityPath)
 }


### PR DESCRIPTION
in order to fix the false legend behavior in the ctsapp, this fix should be done here